### PR TITLE
[codex] Add ambient Node proxy agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added ambient Node proxy helper exports and replaced the `proxy-agent` dependency with Proxyline's scoped HTTP/HTTPS Node agent.
+
 ## 0.1.1 - 2026-05-12
 
 - Hardened ambient proxy routing, CONNECT target validation, undici dispatcher cleanup, and generated package output after the runtime module split.

--- a/README.md
+++ b/README.md
@@ -88,11 +88,14 @@ const socket = await openProxyConnectTunnel({
 ```ts
 import { createAmbientNodeProxyAgent } from "@openclaw/proxyline";
 
-const agent = createAmbientNodeProxyAgent({ protocol: "https" });
+const agent = createAmbientNodeProxyAgent({
+  protocol: "https",
+  proxyTls: { caFile: "/etc/proxy-ca.pem" },
+});
 ```
 
 The helper returns `undefined` when ambient proxy env is not configured, so callers can pass an agent only when needed.
-It uses Proxyline's built-in HTTP/HTTPS Node agent; SOCKS and PAC proxy schemes remain unsupported.
+It uses Proxyline's built-in HTTP/HTTPS Node agent, and `proxyTls` applies only to HTTPS proxy endpoints. SOCKS and PAC proxy schemes remain unsupported.
 
 ## Feature matrix
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ const socket = await openProxyConnectTunnel({
 });
 ```
 
+### Conditional Node agent
+
+```ts
+import { createAmbientNodeProxyAgent } from "@openclaw/proxyline";
+
+const agent = createAmbientNodeProxyAgent({ protocol: "https" });
+```
+
+The helper returns `undefined` when ambient proxy env is not configured, so callers can pass an agent only when needed.
+It uses Proxyline's built-in HTTP/HTTPS Node agent; SOCKS and PAC proxy schemes remain unsupported.
+
 ## Feature matrix
 
 | Surface | Covered | Notes |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,7 +40,10 @@ hasAmbientNodeProxyConfigured({ protocol: "https" });
 Returns a Proxyline-backed Node agent when ambient env proxy settings apply, or `undefined` when no proxy is configured for the requested protocol. This is for libraries that accept a Node `agent` option but should stay direct when the operator has no proxy env configured.
 
 ```ts
-const agent = createAmbientNodeProxyAgent({ protocol: "https" });
+const agent = createAmbientNodeProxyAgent({
+  protocol: "https",
+  proxyTls: { caFile: "/etc/proxy-ca.pem" },
+});
 ```
 
 ### `redactProxyUrl(value: string | URL): string`
@@ -216,8 +219,10 @@ type OpenProxyConnectTunnelOptions = Readonly<{
 type AmbientNodeProxyAgentOptions = {
   env?: ProxyEnvSnapshot;
   protocol?: "http" | "https";
+  proxyTls?: ProxylineTlsOptions;
 };
 ```
 
 - `env` — optional env snapshot. Defaults to reading process env.
 - `protocol` — probe protocol, defaulting to `"https"`.
+- `proxyTls` — CA trust for HTTPS proxy endpoints. See [Proxy TLS](./proxy-tls.md).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Every public export, with the exact shape from `src/index.ts` and `src/connect.ts`.
+Every public export, with the exact shape from `src/index.ts`, `src/connect.ts`, and `src/node-http.ts`.
 
 ## Functions
 
@@ -17,7 +17,7 @@ In managed mode (and active ambient mode), `installProxyline`:
 - Captures originals for `http.request`, `http.get`, `http.globalAgent`, `https.request`, `https.get`, `https.globalAgent`.
 - Captures the current undici global dispatcher and fetch globals.
 - Installs patched `http.request`/`get`, `https.request`/`get`.
-- Replaces `http.globalAgent` and `https.globalAgent` with a `proxy-agent` `ProxyAgent`.
+- Replaces `http.globalAgent` and `https.globalAgent` with Proxyline's HTTP/HTTPS Node agent.
 - Calls `undici.setGlobalDispatcher` with a `ProxyAgent` (managed) or Proxyline's ambient dispatcher (ambient), and patches `globalThis.fetch` plus `Request`, `Response`, `Headers`, and `FormData` to use that dispatcher-compatible fetch stack.
 - Emits `runtime.installed`.
 
@@ -26,6 +26,22 @@ In inactive ambient mode (no supported proxy env variables), no patches are inst
 ### `openProxyConnectTunnel(options): Promise<net.Socket | tls.TLSSocket>`
 
 Opens a one-shot HTTP CONNECT tunnel through a proxy. See [Surfaces — HTTP CONNECT tunnel](./surfaces.md#http-connect-tunnel).
+
+### `hasAmbientNodeProxyConfigured(options?): boolean`
+
+Returns `true` when the ambient proxy environment would proxy a probe URL for the requested protocol. Defaults to `protocol: "https"`.
+
+```ts
+hasAmbientNodeProxyConfigured({ protocol: "https" });
+```
+
+### `createAmbientNodeProxyAgent(options?): http.Agent | undefined`
+
+Returns a Proxyline-backed Node agent when ambient env proxy settings apply, or `undefined` when no proxy is configured for the requested protocol. This is for libraries that accept a Node `agent` option but should stay direct when the operator has no proxy env configured.
+
+```ts
+const agent = createAmbientNodeProxyAgent({ protocol: "https" });
+```
 
 ### `redactProxyUrl(value: string | URL): string`
 
@@ -193,3 +209,15 @@ type OpenProxyConnectTunnelOptions = Readonly<{
 - `proxyTls` — CA trust for HTTPS proxies. See [Proxy TLS](./proxy-tls.md).
 - `targetHost` / `targetPort` — what to ask the proxy to connect to.
 - `timeoutMs` — overall budget for the CONNECT handshake.
+
+### `AmbientNodeProxyAgentOptions`
+
+```ts
+type AmbientNodeProxyAgentOptions = {
+  env?: ProxyEnvSnapshot;
+  protocol?: "http" | "https";
+};
+```
+
+- `env` — optional env snapshot. Defaults to reading process env.
+- `protocol` — probe protocol, defaulting to `"https"`.

--- a/docs/proxy-tls.md
+++ b/docs/proxy-tls.md
@@ -22,7 +22,7 @@ type ProxylineTlsOptions = Readonly<{
 
 Pass exactly one. `ca` wins when both are provided. The resolved PEM is forwarded to:
 
-- The internal `proxy-agent` `ProxyAgent` used for `node:http` and `node:https`.
+- The internal Proxyline Node agent used for `node:http` and `node:https`.
 - The undici `ProxyAgent` (managed) or Proxyline's ambient dispatcher (ambient).
 - The `tls.connect` call inside `openProxyConnectTunnel` when the proxy URL is `https://`.
 

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -16,7 +16,7 @@ Per request, Proxyline:
 1. Copies the call's options object so caller state is not mutated.
 2. Reads TLS-relevant options off any caller-supplied `agent` and lifts them onto the request options (see [TLS identity preservation](#tls-identity-preservation)).
 3. Sets `servername` to the destination hostname when not already set and the hostname is not an IP literal.
-4. Builds a fresh `proxy-agent` `ProxyAgent` for the request and assigns it as `options.agent`.
+4. Builds a fresh Proxyline Node agent for the request and assigns it as `options.agent`.
 5. Deletes any `createConnection` override so callers cannot punch through to the kernel directly.
 6. Destroys the per-request proxy agent when the request closes.
 
@@ -106,6 +106,7 @@ This is intentional: a common bypass is `new https.Agent({ keepAlive: true })` p
 To get a proxy-aware agent without going through the patched globals, use:
 
 - `proxy.createNodeAgent()` — an `http.Agent` that proxies HTTP and HTTPS requests.
+- `createAmbientNodeProxyAgent()` — a standalone ambient helper that returns an agent only when proxy env applies.
 - `proxy.createUndiciDispatcher()` — an undici `Dispatcher` mirroring the current mode.
 - `proxy.createWebSocketAgent()` — an `http.Agent` suitable for WebSocket upgrades.
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "node": ">=20.18.1"
   },
   "dependencies": {
-    "proxy-agent": "^8.0.1",
     "undici": "^7.25.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      proxy-agent:
-        specifier: ^8.0.1
-        version: 8.0.1
       undici:
         specifier: ^7.25.0
         version: 7.25.0
@@ -195,59 +192,10 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/@types/ws/-/ws-8.18.1.tgz}
 
-  agent-base@9.0.0:
-    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/agent-base/-/agent-base-9.0.0.tgz}
-    engines: {node: '>= 20'}
-
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/ast-types/-/ast-types-0.13.4.tgz}
-    engines: {node: '>=4'}
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/basic-ftp/-/basic-ftp-5.3.1.tgz}
-    engines: {node: '>=10.0.0'}
-
-  data-uri-to-buffer@8.0.0:
-    resolution: {integrity: sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==, tarball: https://packages.atlassian.com/api/npm/npm-remote/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz}
-    engines: {node: '>= 20'}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/debug/-/debug-4.4.3.tgz}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  degenerator@7.0.1:
-    resolution: {integrity: sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/degenerator/-/degenerator-7.0.1.tgz}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      quickjs-wasi: ^2.2.0
-
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/esbuild/-/esbuild-0.27.7.tgz}
     engines: {node: '>=18'}
     hasBin: true
-
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/escodegen/-/escodegen-2.1.0.tgz}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==, tarball: https://packages.atlassian.com/api/npm/npm-remote/esprima/-/esprima-4.0.1.tgz}
-    engines: {node: '>=4'}
-    hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/estraverse/-/estraverse-5.3.0.tgz}
-    engines: {node: '>=4.0'}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/esutils/-/esutils-2.0.3.tgz}
-    engines: {node: '>=0.10.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/fsevents/-/fsevents-2.3.3.tgz}
@@ -257,75 +205,8 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/get-tsconfig/-/get-tsconfig-4.14.0.tgz}
 
-  get-uri@8.0.0:
-    resolution: {integrity: sha512-CqtZlMKvfJeY0Zxv8wazDwXmSKmnMnsmNy8j8+wudi8EyG/pMUB1NqHc+Tv1QaNtpYsK9nOYjb7r7Ufu32RPSw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/get-uri/-/get-uri-8.0.0.tgz}
-    engines: {node: '>= 20'}
-
-  http-proxy-agent@9.0.0:
-    resolution: {integrity: sha512-FcF8VhXYLQcxWCnt/cCpT2apKsRDUGeVEeMqGu4HSTu29U8Yw0TLOjdYIlDsYk3IkUh+taX4IDWpPcCqKDhCjA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/http-proxy-agent/-/http-proxy-agent-9.0.0.tgz}
-    engines: {node: '>= 20'}
-
-  https-proxy-agent@9.0.0:
-    resolution: {integrity: sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz}
-    engines: {node: '>= 20'}
-
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/ip-address/-/ip-address-10.2.0.tgz}
-    engines: {node: '>= 12'}
-
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/lru-cache/-/lru-cache-7.18.3.tgz}
-    engines: {node: '>=12'}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/ms/-/ms-2.1.3.tgz}
-
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/netmask/-/netmask-2.1.1.tgz}
-    engines: {node: '>= 0.4.0'}
-
-  pac-proxy-agent@9.0.1:
-    resolution: {integrity: sha512-3ZOSpLboOlpW4yp8Cuv21KlTULRqyJ5Uuad3wXpSKFrxdNgcHEyoa22GRaZ2UlgCVuR6z+5BiavtYVvbajL/Yw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/pac-proxy-agent/-/pac-proxy-agent-9.0.1.tgz}
-    engines: {node: '>= 20'}
-
-  pac-resolver@9.0.1:
-    resolution: {integrity: sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/pac-resolver/-/pac-resolver-9.0.1.tgz}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      quickjs-wasi: ^2.2.0
-
-  proxy-agent@8.0.1:
-    resolution: {integrity: sha512-kccqGBqHZXR8onQhY/ganJjoO8QIKKRiFBhPOzbTZK16attzSZ/0XSmp9H7jrRxPKHjhGyx1q32lMPrJ3uLFgA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/proxy-agent/-/proxy-agent-8.0.1.tgz}
-    engines: {node: '>= 20'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/proxy-from-env/-/proxy-from-env-2.1.0.tgz}
-    engines: {node: '>=10'}
-
-  quickjs-wasi@2.2.0:
-    resolution: {integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz}
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==, tarball: https://packages.atlassian.com/api/npm/npm-remote/smart-buffer/-/smart-buffer-4.2.0.tgz}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@10.0.0:
-    resolution: {integrity: sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==, tarball: https://packages.atlassian.com/api/npm/npm-remote/socks-proxy-agent/-/socks-proxy-agent-10.0.0.tgz}
-    engines: {node: '>= 20'}
-
-  socks@2.8.8:
-    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==, tarball: https://packages.atlassian.com/api/npm/npm-remote/socks/-/socks-2.8.8.tgz}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==, tarball: https://packages.atlassian.com/api/npm/npm-remote/source-map/-/source-map-0.6.1.tgz}
-    engines: {node: '>=0.10.0'}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==, tarball: https://packages.atlassian.com/api/npm/npm-remote/tslib/-/tslib-2.8.1.tgz}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==, tarball: https://packages.atlassian.com/api/npm/npm-remote/tsx/-/tsx-4.21.0.tgz}
@@ -444,27 +325,6 @@ snapshots:
     dependencies:
       '@types/node': 20.19.40
 
-  agent-base@9.0.0: {}
-
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
-
-  basic-ftp@5.3.1: {}
-
-  data-uri-to-buffer@8.0.0: {}
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
-  degenerator@7.0.1(quickjs-wasi@2.2.0):
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
-      quickjs-wasi: 2.2.0
-
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -494,20 +354,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
-  esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
-
-  esutils@2.0.3: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -515,93 +361,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@8.0.0:
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 8.0.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  http-proxy-agent@9.0.0:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@9.0.0:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
-  ip-address@10.2.0: {}
-
-  lru-cache@7.18.3: {}
-
-  ms@2.1.3: {}
-
-  netmask@2.1.1: {}
-
-  pac-proxy-agent@9.0.1:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3
-      get-uri: 8.0.0
-      http-proxy-agent: 9.0.0
-      https-proxy-agent: 9.0.0
-      pac-resolver: 9.0.1(quickjs-wasi@2.2.0)
-      quickjs-wasi: 2.2.0
-      socks-proxy-agent: 10.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@9.0.1(quickjs-wasi@2.2.0):
-    dependencies:
-      degenerator: 7.0.1(quickjs-wasi@2.2.0)
-      netmask: 2.1.1
-      quickjs-wasi: 2.2.0
-
-  proxy-agent@8.0.1:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3
-      http-proxy-agent: 9.0.0
-      https-proxy-agent: 9.0.0
-      lru-cache: 7.18.3
-      pac-proxy-agent: 9.0.1
-      proxy-from-env: 2.1.0
-      socks-proxy-agent: 10.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@2.1.0: {}
-
-  quickjs-wasi@2.2.0: {}
-
   resolve-pkg-maps@1.0.0: {}
-
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@10.0.0:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3
-      socks: 2.8.8
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.8:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-
-  source-map@0.6.1:
-    optional: true
-
-  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
 export { openProxyConnectTunnel, type OpenProxyConnectTunnelOptions } from "./connect.js";
+export {
+  createAmbientNodeProxyAgent,
+  hasAmbientNodeProxyConfigured,
+  type AmbientNodeProxyAgentOptions,
+} from "./node-http.js";
 export { installGlobalProxy, installProxyline } from "./runtime.js";
 export {
   ProxylineError,

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -625,14 +625,23 @@ class ProxylineConnectAgent extends http.Agent {
       tlsSocket = currentTlsSocket;
       this.#pendingConnectSockets.add(currentTlsSocket);
       const onTlsError = (error: Error): void => {
+        currentTlsSocket.off("close", onTlsClosed);
         finish(error, currentTlsSocket);
       };
       const onTlsSecureConnect = (): void => {
         currentTlsSocket.off("error", onTlsError);
+        currentTlsSocket.off("close", onTlsClosed);
         finish(null, currentTlsSocket);
+      };
+      const onTlsClosed = (): void => {
+        finish(
+          new ProxylineError("CONNECT_FAILED", "destination TLS socket closed before secureConnect"),
+          currentTlsSocket,
+        );
       };
       currentTlsSocket.once("secureConnect", onTlsSecureConnect);
       currentTlsSocket.once("error", onTlsError);
+      currentTlsSocket.once("close", onTlsClosed);
     };
 
     const onError = (error: Error): void => {

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -40,6 +40,7 @@ type NodeProxyAgentOptions = NodeAgentOptions & {
 };
 
 const MAX_CONNECT_RESPONSE_HEADER_BYTES = 16 * 1024;
+const INVALID_PROXY_TARGET_HOST_DELIMITER_PATTERN = /[/:?#@\\]/;
 const nodeAgentDefaultPorts = new WeakMap<object, number>();
 
 export const CALLER_AGENT_TLS_OPTION_KEYS = [
@@ -260,16 +261,20 @@ function requestAuthority(options: NodeAgentRequestOptions): string {
   return port === undefined ? authorityHost : `${authorityHost}:${port}`;
 }
 
-function requestUrl(
+function requestDestinationUrl(
   req: http.ClientRequest,
   options: NodeAgentRequestOptions,
   stackProtocol: "http" | "https" | undefined,
 ): string {
-  if (!shouldTunnelRequest(req, options, stackProtocol) && /^(?:https?|wss?):\/\//i.test(req.path)) {
-    return new URL(req.path).href;
-  }
   const path = req.path.startsWith("/") ? req.path : `/${req.path}`;
   return `${requestProtocol(req, options, stackProtocol)}//${requestAuthority(options)}${path}`;
+}
+
+function proxyForwardRequestPath(req: http.ClientRequest, options: NodeAgentRequestOptions): string {
+  if (/^(?:https?|wss?):\/\//i.test(req.path)) {
+    return new URL(req.path).href;
+  }
+  return requestDestinationUrl(req, options, undefined);
 }
 
 function setProxyRequestHeaders(req: http.ClientRequest, proxy: URL, keepAlive: boolean): void {
@@ -287,7 +292,7 @@ function setForwardProxyRequestPath(
   options: NodeAgentRequestOptions,
 ): void {
   req._header = null;
-  req.path = requestUrl(req, options, undefined);
+  req.path = proxyForwardRequestPath(req, options);
 }
 
 function connectToProxy(
@@ -349,6 +354,9 @@ function normalizeProxyTargetHost(host: string): string {
     host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
   if (net.isIP(unbracketedHost) !== 0) {
     return unbracketedHost;
+  }
+  if (INVALID_PROXY_TARGET_HOST_DELIMITER_PATTERN.test(host)) {
+    throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target host contains unsafe delimiters.");
   }
   const asciiHost = domainToASCII(host);
   if (!asciiHost) {
@@ -771,7 +779,7 @@ export class ProxylineNodeProxyAgent extends http.Agent {
       stackProtocol === "https" && options.secureEndpoint !== true
         ? { ...options, secureEndpoint: true }
         : options;
-    const url = requestUrl(req, agentOptions, stackProtocol);
+    const url = requestDestinationUrl(req, agentOptions, stackProtocol);
     const proxy = this.#getProxyForUrl(url, req);
     if (!proxy) {
       (isSecureEndpoint(agentOptions, stackProtocol) ? this.#httpsAgent : this.#httpAgent)

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -224,9 +224,37 @@ function requestProtocol(req: http.ClientRequest, options: NodeAgentRequestOptio
   return isWebSocket ? "ws:" : "http:";
 }
 
+function normalizedPort(value: unknown): number | undefined {
+  if (typeof value !== "number" && typeof value !== "string") {
+    return undefined;
+  }
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : undefined;
+}
+
+function normalizedPositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" && typeof value !== "string") {
+    return undefined;
+  }
+  const integer = Number(value);
+  return Number.isInteger(integer) && integer > 0 ? integer : undefined;
+}
+
+function requestAuthority(options: NodeAgentRequestOptions): string {
+  const rawHost = options.hostname ?? options.host ?? "localhost";
+  const parsed = splitHostPort(String(rawHost));
+  const host = parsed.host || "localhost";
+  const port = parsed.port ?? normalizedPort(options.port);
+  const authorityHost = net.isIPv6(host) ? `[${host}]` : host;
+  return port === undefined ? authorityHost : `${authorityHost}:${port}`;
+}
+
 function requestUrl(req: http.ClientRequest, options: NodeAgentRequestOptions): string {
-  const host = req.getHeader("host") ?? options.host ?? options.hostname ?? "localhost";
-  return new URL(req.path, `${requestProtocol(req, options)}//${String(host)}`).href;
+  if (/^(?:https?|wss?):\/\//i.test(req.path)) {
+    return new URL(req.path).href;
+  }
+  const path = req.path.startsWith("/") ? req.path : `/${req.path}`;
+  return `${requestProtocol(req, options)}//${requestAuthority(options)}${path}`;
 }
 
 function setProxyRequestHeaders(req: http.ClientRequest, proxy: URL, keepAlive: boolean): void {
@@ -363,6 +391,8 @@ class ProxylineHttpForwardAgent extends http.Agent {
 class ProxylineConnectAgent extends http.Agent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
+  readonly #pendingRequests = new WeakMap<NodeAgentRequestOptions, http.ClientRequest>();
+  readonly #pendingRequestQueue: http.ClientRequest[] = [];
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
@@ -375,7 +405,24 @@ class ProxylineConnectAgent extends http.Agent {
   }
 
   public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
-    (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    this.#pendingRequests.set(options, req);
+    this.#pendingRequestQueue.push(req);
+    req.once("socket", () => this.#removePendingRequest(req));
+    req.once("close", () => this.#removePendingRequest(req));
+    try {
+      (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    } catch (error) {
+      this.#pendingRequests.delete(options);
+      this.#removePendingRequest(req);
+      throw error;
+    }
+  }
+
+  #removePendingRequest(req: http.ClientRequest): void {
+    const index = this.#pendingRequestQueue.indexOf(req);
+    if (index !== -1) {
+      this.#pendingRequestQueue.splice(index, 1);
+    }
   }
 
   public override createConnection(
@@ -383,21 +430,36 @@ class ProxylineConnectAgent extends http.Agent {
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
     const proxySocket = connectToProxy(this.#proxy, this.#proxyTls);
+    const mappedRequest = this.#pendingRequests.get(options);
+    const request = mappedRequest ?? this.#pendingRequestQueue.shift();
+    this.#pendingRequests.delete(options);
+    if (mappedRequest !== undefined) {
+      this.#removePendingRequest(mappedRequest);
+    }
     if (callback === undefined) {
       proxySocket.destroy();
       throw new ProxylineError("INVALID_CONNECT_CALLBACK", "CONNECT agents require an async socket callback.");
     }
 
+    let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
     let settled = false;
     let responseBuffer = Buffer.alloc(0);
 
     const cleanup = (): void => {
+      if (pendingTimeout !== undefined) {
+        clearTimeout(pendingTimeout);
+        pendingTimeout = undefined;
+      }
       proxySocket.off("data", onData);
       proxySocket.off("error", onError);
       proxySocket.off("end", onClosed);
       proxySocket.off("close", onClosed);
       proxySocket.off("connect", onConnected);
       proxySocket.off("secureConnect", onConnected);
+      request?.off("abort", onRequestClosed);
+      request?.off("close", onRequestClosed);
+      request?.off("error", onRequestClosed);
+      request?.off("timeout", onRequestTimedOut);
     };
 
     const finish = (error: Error | null, socket: net.Socket): void => {
@@ -485,6 +547,34 @@ class ProxylineConnectAgent extends http.Agent {
     const onClosed = (): void => {
       fail(new ProxylineError("CONNECT_FAILED", "proxy socket closed before CONNECT completed"));
     };
+
+    const onRequestClosed = (): void => {
+      if (!settled) {
+        fail(new ProxylineError("CONNECT_FAILED", "request closed before proxy CONNECT completed"));
+      }
+    };
+
+    const onRequestTimedOut = (): void => {
+      if (!settled) {
+        fail(new ProxylineError("CONNECT_FAILED", "proxy CONNECT timed out"));
+      }
+    };
+
+    const requestTimeout = (request as { timeout?: unknown } | undefined)?.timeout;
+    const timeoutMs = normalizedPositiveInteger(options.timeout ?? requestTimeout);
+    if (timeoutMs !== undefined) {
+      pendingTimeout = setTimeout(() => {
+        request?.emit("timeout");
+        if (!settled) {
+          fail(new ProxylineError("CONNECT_FAILED", "proxy CONNECT timed out"));
+        }
+      }, timeoutMs);
+      pendingTimeout.unref?.();
+    }
+    request?.once("abort", onRequestClosed);
+    request?.once("close", onRequestClosed);
+    request?.once("error", onRequestClosed);
+    request?.once("timeout", onRequestTimedOut);
 
     proxySocket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
     proxySocket.on("data", onData);

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -429,6 +429,7 @@ class ProxylineHttpForwardAgent extends http.Agent {
 class ProxylineConnectAgent extends http.Agent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
+  readonly #pendingConnectSockets = new Set<net.Socket>();
   readonly #pendingRequests = new WeakMap<NodeAgentRequestOptions, http.ClientRequest>();
   readonly #pendingRequestQueue: http.ClientRequest[] = [];
   readonly #proxy: URL;
@@ -467,7 +468,6 @@ class ProxylineConnectAgent extends http.Agent {
     options: NodeAgentRequestOptions,
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
-    const proxySocket = connectToProxy(this.#proxy, this.#proxyTls);
     const mappedRequest = this.#pendingRequests.get(options);
     const request = mappedRequest ?? this.#pendingRequestQueue.shift();
     this.#pendingRequests.delete(options);
@@ -475,15 +475,17 @@ class ProxylineConnectAgent extends http.Agent {
       this.#removePendingRequest(mappedRequest);
     }
     if (callback === undefined) {
-      proxySocket.destroy();
       throw new ProxylineError("INVALID_CONNECT_CALLBACK", "CONNECT agents require an async socket callback.");
     }
 
+    const proxySocket = connectToProxy(this.#proxy, this.#proxyTls);
+    this.#pendingConnectSockets.add(proxySocket);
     let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
     let settled = false;
     let responseBuffer = Buffer.alloc(0);
     let originalRequestSetTimeout: RequestSetTimeout | undefined;
     let hookedRequestSetTimeout: RequestSetTimeout | undefined;
+    let tlsSocket: tls.TLSSocket | undefined;
 
     const startPendingTimeout = (timeoutMs: number): void => {
       if (pendingTimeout !== undefined) {
@@ -523,6 +525,10 @@ class ProxylineConnectAgent extends http.Agent {
       if (pendingTimeout !== undefined) {
         clearTimeout(pendingTimeout);
         pendingTimeout = undefined;
+      }
+      this.#pendingConnectSockets.delete(proxySocket);
+      if (tlsSocket !== undefined) {
+        this.#pendingConnectSockets.delete(tlsSocket);
       }
       restoreRequestTimeoutHook();
       cleanupProxyHandshakeListeners();
@@ -599,16 +605,18 @@ class ProxylineConnectAgent extends http.Agent {
         finish(null, proxySocket);
         return;
       }
-      const tlsSocket = tls.connect(destinationTlsConnectOptions(options, proxySocket));
+      const currentTlsSocket = tls.connect(destinationTlsConnectOptions(options, proxySocket));
+      tlsSocket = currentTlsSocket;
+      this.#pendingConnectSockets.add(currentTlsSocket);
       const onTlsError = (error: Error): void => {
-        finish(error, tlsSocket);
+        finish(error, currentTlsSocket);
       };
       const onTlsSecureConnect = (): void => {
-        tlsSocket.off("error", onTlsError);
-        finish(null, tlsSocket);
+        currentTlsSocket.off("error", onTlsError);
+        finish(null, currentTlsSocket);
       };
-      tlsSocket.once("secureConnect", onTlsSecureConnect);
-      tlsSocket.once("error", onTlsError);
+      currentTlsSocket.once("secureConnect", onTlsSecureConnect);
+      currentTlsSocket.once("error", onTlsError);
     };
 
     const onError = (error: Error): void => {
@@ -661,6 +669,14 @@ class ProxylineConnectAgent extends http.Agent {
     proxySocket.once("close", onClosed);
 
     return undefined as unknown as net.Socket;
+  }
+
+  public override destroy(): void {
+    for (const socket of this.#pendingConnectSockets) {
+      socket.destroy();
+    }
+    this.#pendingConnectSockets.clear();
+    super.destroy();
   }
 }
 

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -520,8 +520,9 @@ export class ProxylineNodeProxyAgent extends http.Agent {
   }
 
   public get defaultPort(): number {
+    const stackProtocol = this.#callStackProtocol();
     return nodeAgentDefaultPorts.get(this) ??
-      (this.#isHttpsCallStack() || this.#defaultProtocol === "https" ? 443 : 80);
+      ((stackProtocol ?? this.#defaultProtocol) === "https" ? 443 : 80);
   }
 
   public set defaultPort(value: number) {
@@ -529,7 +530,7 @@ export class ProxylineNodeProxyAgent extends http.Agent {
   }
 
   public get protocol(): string {
-    return this.#isHttpsCallStack() ? "https:" : `${this.#defaultProtocol}:`;
+    return `${this.#callStackProtocol() ?? this.#defaultProtocol}:`;
   }
 
   public set protocol(_value: string) {
@@ -540,12 +541,20 @@ export class ProxylineNodeProxyAgent extends http.Agent {
     return this.#getProxyForUrl(url, request);
   }
 
-  #isHttpsCallStack(): boolean {
+  #callStackProtocol(): "http" | "https" | undefined {
     const stack = new Error().stack;
     if (typeof stack !== "string") {
-      return false;
+      return undefined;
     }
-    return stack.split("\n").some((line) => line.includes("node:https:"));
+    for (const line of stack.split("\n")) {
+      if (line.includes("node:https:")) {
+        return "https";
+      }
+      if (line.includes("node:http:")) {
+        return "http";
+      }
+    }
+    return undefined;
   }
 
   public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -1,7 +1,13 @@
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
-import { ProxyAgent as NodeProxyAgent } from "proxy-agent";
+import tls from "node:tls";
+import {
+  readProxyEnv,
+  resolveAmbientProxyForUrl,
+  type ProxyEnvSnapshot,
+} from "./env.js";
+import { ProxylineError, resolveProxyTlsCa, type ProxylineTlsOptions } from "./shared.js";
 import type { ProxyResolver } from "./types.js";
 
 export type NodeHttpRequestOptions = http.RequestOptions & https.RequestOptions & {
@@ -11,9 +17,22 @@ export type NodeHttpRequestOptions = http.RequestOptions & https.RequestOptions 
 type NodeHttpMethod = typeof http.request;
 type NodeAgentFactory = (options: NodeHttpRequestOptions) => http.Agent;
 type NodeAgentOptions = http.AgentOptions & https.AgentOptions;
+type NodeAgentRequestOptions = http.RequestOptions & https.RequestOptions & {
+  secureEndpoint?: boolean;
+};
+type NodeAddRequestAgent = http.Agent & {
+  addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void;
+};
 type NodeAgentWithOptions = http.Agent & {
   options?: NodeAgentOptions;
 };
+type NodeProxyAgentOptions = NodeAgentOptions & {
+  getProxyForUrl: (url: string, request?: http.ClientRequest) => string;
+  proxyTls?: ProxylineTlsOptions;
+};
+
+const MAX_CONNECT_RESPONSE_HEADER_BYTES = 16 * 1024;
+const nodeAgentDefaultPorts = new WeakMap<object, number>();
 
 export const CALLER_AGENT_TLS_OPTION_KEYS = [
   "ca",
@@ -146,22 +165,456 @@ export function bindNodeHttpMethod<TMethod extends NodeHttpMethod>(
   }) as TMethod;
 }
 
+function proxyHost(proxy: URL): string {
+  return (proxy.hostname || proxy.host).replace(/^\[|\]$/g, "");
+}
+
+function proxyPort(proxy: URL): number {
+  if (proxy.port) {
+    return Number(proxy.port);
+  }
+  return proxy.protocol === "https:" ? 443 : 80;
+}
+
+function proxyAuthorization(proxy: URL): string | undefined {
+  if (!proxy.username && !proxy.password) {
+    return undefined;
+  }
+  const username = decodeURIComponent(proxy.username);
+  const password = decodeURIComponent(proxy.password);
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+}
+
+function proxyConnectOptions(
+  proxy: URL,
+  proxyTls: ProxylineTlsOptions | undefined,
+): net.TcpNetConnectOpts | tls.ConnectionOptions {
+  const host = proxyHost(proxy);
+  const base = {
+    host,
+    port: proxyPort(proxy),
+  };
+  if (proxy.protocol !== "https:") {
+    return base;
+  }
+  const ca = resolveProxyTlsCa(proxyTls);
+  return {
+    ...base,
+    ALPNProtocols: ["http/1.1"],
+    ...(net.isIP(host) === 0 ? { servername: host } : {}),
+    ...(ca !== undefined ? { ca } : {}),
+  };
+}
+
+function assertSupportedNodeProxyProtocol(proxy: URL): void {
+  if (proxy.protocol !== "http:" && proxy.protocol !== "https:") {
+    throw new ProxylineError(
+      "UNSUPPORTED_PROXY_PROTOCOL",
+      `Node HTTP agents support http:// and https:// proxy endpoints: ${proxy.protocol}`,
+    );
+  }
+}
+
+function requestProtocol(req: http.ClientRequest, options: NodeAgentRequestOptions): string {
+  const isWebSocket = isWebSocketRequest(req);
+  if (isSecureEndpoint(options)) {
+    return isWebSocket ? "wss:" : "https:";
+  }
+  return isWebSocket ? "ws:" : "http:";
+}
+
+function requestUrl(req: http.ClientRequest, options: NodeAgentRequestOptions): string {
+  const host = req.getHeader("host") ?? options.host ?? options.hostname ?? "localhost";
+  return new URL(req.path, `${requestProtocol(req, options)}//${String(host)}`).href;
+}
+
+function setProxyRequestHeaders(req: http.ClientRequest, proxy: URL, keepAlive: boolean): void {
+  const authorization = proxyAuthorization(proxy);
+  if (authorization !== undefined) {
+    req.setHeader("Proxy-Authorization", authorization);
+  }
+  if (!req.hasHeader("Proxy-Connection")) {
+    req.setHeader("Proxy-Connection", keepAlive ? "Keep-Alive" : "close");
+  }
+}
+
+function setForwardProxyRequestPath(
+  req: http.ClientRequest & { _header?: string | null },
+  options: NodeAgentRequestOptions,
+): void {
+  req._header = null;
+  req.path = requestUrl(req, options);
+}
+
+function connectToProxy(
+  proxy: URL,
+  proxyTls: ProxylineTlsOptions | undefined,
+): net.Socket | tls.TLSSocket {
+  const options = proxyConnectOptions(proxy, proxyTls);
+  return proxy.protocol === "https:"
+    ? tls.connect(options as tls.ConnectionOptions)
+    : net.connect(options as net.NetConnectOpts);
+}
+
+function isWebSocketRequest(req: http.ClientRequest): boolean {
+  return String(req.getHeader("upgrade") ?? "").toLowerCase() === "websocket";
+}
+
+function isSecureEndpoint(options: NodeAgentRequestOptions): boolean {
+  return (
+    options.secureEndpoint === true ||
+    options.protocol === "https:" ||
+    options.protocol === "wss:" ||
+    options.defaultPort === 443
+  );
+}
+
+function shouldTunnelRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): boolean {
+  return isSecureEndpoint(options) || isWebSocketRequest(req);
+}
+
+function splitHostPort(value: string): { host: string; port?: number } {
+  const bracketed = value.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (bracketed) {
+    return {
+      host: bracketed[1] ?? "",
+      ...(bracketed[2] !== undefined ? { port: Number(bracketed[2]) } : {}),
+    };
+  }
+  const lastColon = value.lastIndexOf(":");
+  const hasSingleColon = lastColon !== -1 && value.indexOf(":") === lastColon;
+  if (hasSingleColon) {
+    const possiblePort = value.slice(lastColon + 1);
+    if (/^\d+$/.test(possiblePort)) {
+      return { host: value.slice(0, lastColon), port: Number(possiblePort) };
+    }
+  }
+  return { host: value };
+}
+
+function connectTarget(options: NodeAgentRequestOptions): { host: string; port: number } {
+  const rawHost = options.hostname ?? options.host;
+  if (typeof rawHost !== "string") {
+    throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target is missing host.");
+  }
+  const parsed = splitHostPort(rawHost);
+  const port = parsed.port ?? Number(options.port);
+  if (!parsed.host || !Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target is missing host or port.");
+  }
+  return { host: parsed.host, port };
+}
+
+function destinationTlsConnectOptions(
+  options: NodeAgentRequestOptions,
+  socket: net.Socket,
+): tls.ConnectionOptions {
+  const target = connectTarget(options);
+  const tlsOptions = { ...options, socket } as tls.ConnectionOptions & Record<string, unknown>;
+  tlsOptions.host = target.host;
+  delete tlsOptions.path;
+  delete tlsOptions.port;
+  delete tlsOptions.secureEndpoint;
+  delete tlsOptions.agent;
+  return tlsOptions;
+}
+
+class ProxylineHttpForwardAgent extends http.Agent {
+  public readonly options: NodeAgentOptions;
+  readonly #keepAlive: boolean;
+  readonly #proxy: URL;
+  readonly #proxyTls: ProxylineTlsOptions | undefined;
+
+  public constructor(proxy: URL, options: NodeAgentOptions, proxyTls: ProxylineTlsOptions | undefined) {
+    super(options);
+    this.options = options;
+    this.#keepAlive = options.keepAlive === true;
+    this.#proxy = proxy;
+    this.#proxyTls = proxyTls;
+  }
+
+  public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
+    setForwardProxyRequestPath(req as http.ClientRequest & { _header?: string | null }, options);
+    setProxyRequestHeaders(req, this.#proxy, this.#keepAlive);
+    (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+  }
+
+  public override createConnection(
+    _options: NodeAgentRequestOptions,
+    callback?: (error: Error | null, socket: net.Socket) => void,
+  ): net.Socket {
+    const socket = connectToProxy(this.#proxy, this.#proxyTls);
+    if (callback !== undefined) {
+      const onError = (error: Error): void => {
+        callback(error, socket);
+      };
+      const onConnected = (): void => {
+        socket.off("error", onError);
+        callback(null, socket);
+      };
+      socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
+      socket.once("error", onError);
+    }
+    return socket;
+  }
+}
+
+class ProxylineConnectAgent extends http.Agent {
+  public readonly options: NodeAgentOptions;
+  readonly #keepAlive: boolean;
+  readonly #proxy: URL;
+  readonly #proxyTls: ProxylineTlsOptions | undefined;
+
+  public constructor(proxy: URL, options: NodeAgentOptions, proxyTls: ProxylineTlsOptions | undefined) {
+    super(options);
+    this.options = options;
+    this.#keepAlive = options.keepAlive === true;
+    this.#proxy = proxy;
+    this.#proxyTls = proxyTls;
+  }
+
+  public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
+    (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+  }
+
+  public override createConnection(
+    options: NodeAgentRequestOptions,
+    callback?: (error: Error | null, socket: net.Socket) => void,
+  ): net.Socket {
+    const proxySocket = connectToProxy(this.#proxy, this.#proxyTls);
+    if (callback === undefined) {
+      proxySocket.destroy();
+      throw new ProxylineError("INVALID_CONNECT_CALLBACK", "CONNECT agents require an async socket callback.");
+    }
+
+    let settled = false;
+    let responseBuffer = Buffer.alloc(0);
+
+    const cleanup = (): void => {
+      proxySocket.off("data", onData);
+      proxySocket.off("error", onError);
+      proxySocket.off("end", onClosed);
+      proxySocket.off("close", onClosed);
+      proxySocket.off("connect", onConnected);
+      proxySocket.off("secureConnect", onConnected);
+    };
+
+    const finish = (error: Error | null, socket: net.Socket): void => {
+      if (settled) {
+        if (error === null) {
+          socket.destroy();
+        }
+        return;
+      }
+      settled = true;
+      cleanup();
+      callback(error, socket);
+    };
+
+    const fail = (error: Error): void => {
+      proxySocket.destroy();
+      finish(error, proxySocket);
+    };
+
+    const onConnected = (): void => {
+      let target: { host: string; port: number };
+      try {
+        target = connectTarget(options);
+      } catch (error) {
+        fail(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+      const { host, port } = target;
+      const authority = net.isIPv6(host) ? `[${host}]:${port}` : `${host}:${port}`;
+      const headers = [
+        `CONNECT ${authority} HTTP/1.1`,
+        `Host: ${authority}`,
+        `Proxy-Connection: ${this.#keepAlive ? "Keep-Alive" : "close"}`,
+      ];
+      const authorization = proxyAuthorization(this.#proxy);
+      if (authorization !== undefined) {
+        headers.push(`Proxy-Authorization: ${authorization}`);
+      }
+      proxySocket.write([...headers, "", ""].join("\r\n"));
+    };
+
+    const onData = (chunk: Buffer): void => {
+      responseBuffer = Buffer.concat([responseBuffer, chunk]);
+      const headerEnd = responseBuffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) {
+        if (responseBuffer.length > MAX_CONNECT_RESPONSE_HEADER_BYTES) {
+          fail(new ProxylineError("CONNECT_FAILED", "proxy CONNECT response headers were too large"));
+        }
+        return;
+      }
+      const bodyOffset = headerEnd + 4;
+      if (bodyOffset > MAX_CONNECT_RESPONSE_HEADER_BYTES) {
+        fail(new ProxylineError("CONNECT_FAILED", "proxy CONNECT response headers were too large"));
+        return;
+      }
+      const statusLine = responseBuffer.subarray(0, bodyOffset).toString("latin1").split("\r\n", 1)[0] ?? "";
+      if (!/^HTTP\/1\.[01] 2\d\d\b/.test(statusLine)) {
+        fail(new ProxylineError("CONNECT_FAILED", statusLine || "proxy returned an invalid CONNECT response"));
+        return;
+      }
+      const tunneledBytes = responseBuffer.subarray(bodyOffset);
+      if (tunneledBytes.length > 0) {
+        proxySocket.unshift(tunneledBytes);
+      }
+      if (!isSecureEndpoint(options)) {
+        finish(null, proxySocket);
+        return;
+      }
+      const tlsSocket = tls.connect(destinationTlsConnectOptions(options, proxySocket));
+      const onTlsError = (error: Error): void => {
+        finish(error, tlsSocket);
+      };
+      const onTlsSecureConnect = (): void => {
+        tlsSocket.off("error", onTlsError);
+        finish(null, tlsSocket);
+      };
+      tlsSocket.once("secureConnect", onTlsSecureConnect);
+      tlsSocket.once("error", onTlsError);
+    };
+
+    const onError = (error: Error): void => {
+      fail(error);
+    };
+
+    const onClosed = (): void => {
+      fail(new ProxylineError("CONNECT_FAILED", "proxy socket closed before CONNECT completed"));
+    };
+
+    proxySocket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
+    proxySocket.on("data", onData);
+    proxySocket.once("error", onError);
+    proxySocket.once("end", onClosed);
+    proxySocket.once("close", onClosed);
+
+    return undefined as unknown as net.Socket;
+  }
+}
+
+export class ProxylineNodeProxyAgent extends http.Agent {
+  public readonly options: NodeAgentOptions;
+  readonly #agents = new Map<string, NodeAddRequestAgent>();
+  readonly #getProxyForUrl: (url: string, request?: http.ClientRequest) => string;
+  readonly #httpAgent: NodeAddRequestAgent;
+  readonly #httpsAgent: NodeAddRequestAgent;
+  readonly #proxyTls: ProxylineTlsOptions | undefined;
+
+  public constructor(options: NodeProxyAgentOptions) {
+    super(options);
+    this.options = options;
+    this.#getProxyForUrl = options.getProxyForUrl;
+    this.#proxyTls = options.proxyTls;
+    this.#httpAgent = new http.Agent(options) as NodeAddRequestAgent;
+    this.#httpsAgent = new https.Agent(options) as unknown as NodeAddRequestAgent;
+  }
+
+  public get defaultPort(): number {
+    return nodeAgentDefaultPorts.get(this) ?? (this.#isSecureEndpoint() ? 443 : 80);
+  }
+
+  public set defaultPort(value: number) {
+    nodeAgentDefaultPorts.set(this, value);
+  }
+
+  public get protocol(): string {
+    return this.#isSecureEndpoint() ? "https:" : "http:";
+  }
+
+  public set protocol(_value: string) {
+    // Node's http.Agent constructor assigns this, but this wrapper is dual-use.
+  }
+
+  public getProxyForUrl(url: string, request?: http.ClientRequest): string {
+    return this.#getProxyForUrl(url, request);
+  }
+
+  #isSecureEndpoint(): boolean {
+    const stack = new Error().stack;
+    if (typeof stack !== "string") {
+      return false;
+    }
+    return stack.split("\n").some((line) => line.includes("node:https:"));
+  }
+
+  public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
+    const url = requestUrl(req, options);
+    const proxy = this.#getProxyForUrl(url, req);
+    if (!proxy) {
+      (isSecureEndpoint(options) ? this.#httpsAgent : this.#httpAgent).addRequest(req, options);
+      return;
+    }
+    const proxyUrl = new URL(proxy);
+    assertSupportedNodeProxyProtocol(proxyUrl);
+    const tunnel = shouldTunnelRequest(req, options);
+    const key = `${tunnel ? "connect" : "forward"}:${proxyUrl.href}`;
+    let agent = this.#agents.get(key);
+    if (agent === undefined) {
+      const newAgent = tunnel
+        ? new ProxylineConnectAgent(proxyUrl, this.options, this.#proxyTls)
+        : new ProxylineHttpForwardAgent(proxyUrl, this.options, this.#proxyTls);
+      agent = newAgent;
+      this.#agents.set(key, agent);
+    }
+    agent.addRequest(req, options);
+  }
+
+  public override destroy(): void {
+    for (const agent of this.#agents.values()) {
+      agent.destroy();
+    }
+    this.#agents.clear();
+    this.#httpAgent.destroy();
+    this.#httpsAgent.destroy();
+    super.destroy();
+  }
+}
+
 export function createNodeProxyAgent(
   resolver: ProxyResolver,
   proxyCa: string | undefined,
-): NodeProxyAgent {
-  return new NodeProxyAgent({
-    ...(proxyCa !== undefined ? { ca: proxyCa } : {}),
+): ProxylineNodeProxyAgent {
+  return new ProxylineNodeProxyAgent({
     getProxyForUrl: resolver.getProxyForUrl,
-    httpAgent: new http.Agent(),
-    httpsAgent: new https.Agent(),
+    ...(proxyCa !== undefined ? { proxyTls: { ca: proxyCa } } : {}),
   });
 }
 
-export function createDirectNodeAgent(): NodeProxyAgent {
-  return new NodeProxyAgent({
+export function createDirectNodeAgent(): ProxylineNodeProxyAgent {
+  return new ProxylineNodeProxyAgent({
     getProxyForUrl: () => "",
-    httpAgent: new http.Agent(),
-    httpsAgent: new https.Agent(),
+  });
+}
+
+export type AmbientNodeProxyAgentOptions = {
+  env?: ProxyEnvSnapshot;
+  protocol?: "http" | "https";
+};
+
+function ambientProbeUrl(protocol: "http" | "https"): string {
+  return `${protocol}://proxyline.invalid/`;
+}
+
+export function hasAmbientNodeProxyConfigured(
+  options: AmbientNodeProxyAgentOptions = {},
+): boolean {
+  const env = options.env ?? readProxyEnv();
+  const protocol = options.protocol ?? "https";
+  return resolveAmbientProxyForUrl(ambientProbeUrl(protocol), env) !== undefined;
+}
+
+export function createAmbientNodeProxyAgent(
+  options: AmbientNodeProxyAgentOptions = {},
+): ProxylineNodeProxyAgent | undefined {
+  const env = options.env ?? readProxyEnv();
+  const protocol = options.protocol ?? "https";
+  if (resolveAmbientProxyForUrl(ambientProbeUrl(protocol), env) === undefined) {
+    return undefined;
+  }
+  return new ProxylineNodeProxyAgent({
+    getProxyForUrl: (url) => resolveAmbientProxyForUrl(url, env) ?? "",
   });
 }

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -23,6 +23,11 @@ type NodeAgentRequestOptions = http.RequestOptions & https.RequestOptions & {
 type NodeAddRequestAgent = http.Agent & {
   addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void;
 };
+type RequestSetTimeout = (
+  this: http.ClientRequest,
+  timeout: number,
+  callback?: () => void,
+) => http.ClientRequest;
 type NodeAgentWithOptions = http.Agent & {
   options?: NodeAgentOptions;
 };
@@ -444,12 +449,40 @@ class ProxylineConnectAgent extends http.Agent {
     let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
     let settled = false;
     let responseBuffer = Buffer.alloc(0);
+    let originalRequestSetTimeout: RequestSetTimeout | undefined;
+    let hookedRequestSetTimeout: RequestSetTimeout | undefined;
+
+    const startPendingTimeout = (timeoutMs: number): void => {
+      if (pendingTimeout !== undefined) {
+        clearTimeout(pendingTimeout);
+      }
+      pendingTimeout = setTimeout(() => {
+        request?.emit("timeout");
+        if (!settled) {
+          fail(new ProxylineError("CONNECT_FAILED", "proxy CONNECT timed out"));
+        }
+      }, timeoutMs);
+      pendingTimeout.unref?.();
+    };
+
+    const restoreRequestTimeoutHook = (): void => {
+      if (
+        request !== undefined &&
+        originalRequestSetTimeout !== undefined &&
+        request.setTimeout === hookedRequestSetTimeout
+      ) {
+        request.setTimeout = originalRequestSetTimeout;
+      }
+      originalRequestSetTimeout = undefined;
+      hookedRequestSetTimeout = undefined;
+    };
 
     const cleanup = (): void => {
       if (pendingTimeout !== undefined) {
         clearTimeout(pendingTimeout);
         pendingTimeout = undefined;
       }
+      restoreRequestTimeoutHook();
       proxySocket.off("data", onData);
       proxySocket.off("error", onError);
       proxySocket.off("end", onClosed);
@@ -560,16 +593,23 @@ class ProxylineConnectAgent extends http.Agent {
       }
     };
 
+    if (request !== undefined) {
+      originalRequestSetTimeout = request.setTimeout;
+      hookedRequestSetTimeout = function hookedSetTimeout(timeout, callback) {
+        const result = originalRequestSetTimeout?.call(this, timeout, callback) ?? this;
+        const timeoutMs = normalizedPositiveInteger(timeout);
+        if (timeoutMs !== undefined) {
+          startPendingTimeout(timeoutMs);
+        }
+        return result;
+      };
+      request.setTimeout = hookedRequestSetTimeout;
+    }
+
     const requestTimeout = (request as { timeout?: unknown } | undefined)?.timeout;
     const timeoutMs = normalizedPositiveInteger(options.timeout ?? requestTimeout);
     if (timeoutMs !== undefined) {
-      pendingTimeout = setTimeout(() => {
-        request?.emit("timeout");
-        if (!settled) {
-          fail(new ProxylineError("CONNECT_FAILED", "proxy CONNECT timed out"));
-        }
-      }, timeoutMs);
-      pendingTimeout.unref?.();
+      startPendingTimeout(timeoutMs);
     }
     request?.once("abort", onRequestClosed);
     request?.once("close", onRequestClosed);
@@ -633,14 +673,22 @@ export class ProxylineNodeProxyAgent extends http.Agent {
 
   #callStackProtocol(): "http" | "https" | undefined {
     const originalStackTraceLimit = Error.stackTraceLimit;
+    const errorConstructor = Error as unknown as { prepareStackTrace?: unknown };
+    const originalPrepareStackTrace = errorConstructor.prepareStackTrace;
     if (typeof originalStackTraceLimit === "number" && originalStackTraceLimit < 20) {
       // Node reads agent.protocol/defaultPort before addRequest, so this is the only caller signal.
       Error.stackTraceLimit = 20;
     }
     let stack: string | undefined;
     try {
+      delete errorConstructor.prepareStackTrace;
       stack = new Error().stack;
     } finally {
+      if (originalPrepareStackTrace === undefined) {
+        delete errorConstructor.prepareStackTrace;
+      } else {
+        errorConstructor.prepareStackTrace = originalPrepareStackTrace;
+      }
       Error.stackTraceLimit = originalStackTraceLimit;
     }
     if (typeof stack !== "string") {

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -477,18 +477,22 @@ class ProxylineConnectAgent extends http.Agent {
       hookedRequestSetTimeout = undefined;
     };
 
-    const cleanup = (): void => {
-      if (pendingTimeout !== undefined) {
-        clearTimeout(pendingTimeout);
-        pendingTimeout = undefined;
-      }
-      restoreRequestTimeoutHook();
+    const cleanupProxyHandshakeListeners = (): void => {
       proxySocket.off("data", onData);
       proxySocket.off("error", onError);
       proxySocket.off("end", onClosed);
       proxySocket.off("close", onClosed);
       proxySocket.off("connect", onConnected);
       proxySocket.off("secureConnect", onConnected);
+    };
+
+    const cleanup = (): void => {
+      if (pendingTimeout !== undefined) {
+        clearTimeout(pendingTimeout);
+        pendingTimeout = undefined;
+      }
+      restoreRequestTimeoutHook();
+      cleanupProxyHandshakeListeners();
       request?.off("abort", onRequestClosed);
       request?.off("close", onRequestClosed);
       request?.off("error", onRequestClosed);
@@ -554,6 +558,7 @@ class ProxylineConnectAgent extends http.Agent {
         return;
       }
       const tunneledBytes = responseBuffer.subarray(bodyOffset);
+      cleanupProxyHandshakeListeners();
       if (tunneledBytes.length > 0) {
         proxySocket.unshift(tunneledBytes);
       }
@@ -675,7 +680,7 @@ export class ProxylineNodeProxyAgent extends http.Agent {
     const originalStackTraceLimit = Error.stackTraceLimit;
     const errorConstructor = Error as unknown as { prepareStackTrace?: unknown };
     const originalPrepareStackTrace = errorConstructor.prepareStackTrace;
-    if (typeof originalStackTraceLimit === "number" && originalStackTraceLimit < 20) {
+    if (typeof originalStackTraceLimit !== "number" || originalStackTraceLimit < 20) {
       // Node reads agent.protocol/defaultPort before addRequest, so this is the only caller signal.
       Error.stackTraceLimit = 20;
     }

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -221,9 +221,13 @@ function assertSupportedNodeProxyProtocol(proxy: URL): void {
   }
 }
 
-function requestProtocol(req: http.ClientRequest, options: NodeAgentRequestOptions): string {
+function requestProtocol(
+  req: http.ClientRequest,
+  options: NodeAgentRequestOptions,
+  stackProtocol: "http" | "https" | undefined,
+): string {
   const isWebSocket = isWebSocketRequest(req);
-  if (isSecureEndpoint(options)) {
+  if (isSecureEndpoint(options, stackProtocol)) {
     return isWebSocket ? "wss:" : "https:";
   }
   return isWebSocket ? "ws:" : "http:";
@@ -254,12 +258,16 @@ function requestAuthority(options: NodeAgentRequestOptions): string {
   return port === undefined ? authorityHost : `${authorityHost}:${port}`;
 }
 
-function requestUrl(req: http.ClientRequest, options: NodeAgentRequestOptions): string {
+function requestUrl(
+  req: http.ClientRequest,
+  options: NodeAgentRequestOptions,
+  stackProtocol: "http" | "https" | undefined,
+): string {
   if (/^(?:https?|wss?):\/\//i.test(req.path)) {
     return new URL(req.path).href;
   }
   const path = req.path.startsWith("/") ? req.path : `/${req.path}`;
-  return `${requestProtocol(req, options)}//${requestAuthority(options)}${path}`;
+  return `${requestProtocol(req, options, stackProtocol)}//${requestAuthority(options)}${path}`;
 }
 
 function setProxyRequestHeaders(req: http.ClientRequest, proxy: URL, keepAlive: boolean): void {
@@ -277,7 +285,7 @@ function setForwardProxyRequestPath(
   options: NodeAgentRequestOptions,
 ): void {
   req._header = null;
-  req.path = requestUrl(req, options);
+  req.path = requestUrl(req, options, undefined);
 }
 
 function connectToProxy(
@@ -294,8 +302,12 @@ function isWebSocketRequest(req: http.ClientRequest): boolean {
   return String(req.getHeader("upgrade") ?? "").toLowerCase() === "websocket";
 }
 
-function isSecureEndpoint(options: NodeAgentRequestOptions): boolean {
+function isSecureEndpoint(
+  options: NodeAgentRequestOptions,
+  stackProtocol?: "http" | "https",
+): boolean {
   return (
+    stackProtocol === "https" ||
     options.secureEndpoint === true ||
     options.protocol === "https:" ||
     options.protocol === "wss:" ||
@@ -303,8 +315,12 @@ function isSecureEndpoint(options: NodeAgentRequestOptions): boolean {
   );
 }
 
-function shouldTunnelRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): boolean {
-  return isSecureEndpoint(options) || isWebSocketRequest(req);
+function shouldTunnelRequest(
+  req: http.ClientRequest,
+  options: NodeAgentRequestOptions,
+  stackProtocol: "http" | "https" | undefined,
+): boolean {
+  return isSecureEndpoint(options, stackProtocol) || isWebSocketRequest(req);
 }
 
 function splitHostPort(value: string): { host: string; port?: number } {
@@ -711,15 +727,21 @@ export class ProxylineNodeProxyAgent extends http.Agent {
   }
 
   public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
-    const url = requestUrl(req, options);
+    const stackProtocol = this.#callStackProtocol();
+    const agentOptions =
+      stackProtocol === "https" && options.secureEndpoint !== true
+        ? { ...options, secureEndpoint: true }
+        : options;
+    const url = requestUrl(req, agentOptions, stackProtocol);
     const proxy = this.#getProxyForUrl(url, req);
     if (!proxy) {
-      (isSecureEndpoint(options) ? this.#httpsAgent : this.#httpAgent).addRequest(req, options);
+      (isSecureEndpoint(agentOptions, stackProtocol) ? this.#httpsAgent : this.#httpAgent)
+        .addRequest(req, agentOptions);
       return;
     }
     const proxyUrl = new URL(proxy);
     assertSupportedNodeProxyProtocol(proxyUrl);
-    const tunnel = shouldTunnelRequest(req, options);
+    const tunnel = shouldTunnelRequest(req, agentOptions, stackProtocol);
     const key = `${tunnel ? "connect" : "forward"}:${proxyUrl.href}`;
     let agent = this.#agents.get(key);
     if (agent === undefined) {
@@ -729,7 +751,7 @@ export class ProxylineNodeProxyAgent extends http.Agent {
       agent = newAgent;
       this.#agents.set(key, agent);
     }
-    agent.addRequest(req, options);
+    agent.addRequest(req, agentOptions);
   }
 
   public override destroy(): void {

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -27,6 +27,7 @@ type NodeAgentWithOptions = http.Agent & {
   options?: NodeAgentOptions;
 };
 type NodeProxyAgentOptions = NodeAgentOptions & {
+  defaultProtocol?: "http" | "https";
   getProxyForUrl: (url: string, request?: http.ClientRequest) => string;
   proxyTls?: ProxylineTlsOptions;
 };
@@ -498,22 +499,29 @@ class ProxylineConnectAgent extends http.Agent {
 export class ProxylineNodeProxyAgent extends http.Agent {
   public readonly options: NodeAgentOptions;
   readonly #agents = new Map<string, NodeAddRequestAgent>();
+  readonly #defaultProtocol: "http" | "https";
   readonly #getProxyForUrl: (url: string, request?: http.ClientRequest) => string;
   readonly #httpAgent: NodeAddRequestAgent;
   readonly #httpsAgent: NodeAddRequestAgent;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
   public constructor(options: NodeProxyAgentOptions) {
-    super(options);
-    this.options = options;
-    this.#getProxyForUrl = options.getProxyForUrl;
-    this.#proxyTls = options.proxyTls;
-    this.#httpAgent = new http.Agent(options) as NodeAddRequestAgent;
-    this.#httpsAgent = new https.Agent(options) as unknown as NodeAddRequestAgent;
+    const { defaultProtocol = "http", getProxyForUrl, proxyTls, ...agentOptions } = options;
+    super(agentOptions);
+    if (nodeAgentDefaultPorts.get(this) === 80) {
+      nodeAgentDefaultPorts.delete(this);
+    }
+    this.options = agentOptions;
+    this.#defaultProtocol = defaultProtocol;
+    this.#getProxyForUrl = getProxyForUrl;
+    this.#proxyTls = proxyTls;
+    this.#httpAgent = new http.Agent(agentOptions) as NodeAddRequestAgent;
+    this.#httpsAgent = new https.Agent(agentOptions) as unknown as NodeAddRequestAgent;
   }
 
   public get defaultPort(): number {
-    return nodeAgentDefaultPorts.get(this) ?? (this.#isSecureEndpoint() ? 443 : 80);
+    return nodeAgentDefaultPorts.get(this) ??
+      (this.#isHttpsCallStack() || this.#defaultProtocol === "https" ? 443 : 80);
   }
 
   public set defaultPort(value: number) {
@@ -521,7 +529,7 @@ export class ProxylineNodeProxyAgent extends http.Agent {
   }
 
   public get protocol(): string {
-    return this.#isSecureEndpoint() ? "https:" : "http:";
+    return this.#isHttpsCallStack() ? "https:" : `${this.#defaultProtocol}:`;
   }
 
   public set protocol(_value: string) {
@@ -532,7 +540,7 @@ export class ProxylineNodeProxyAgent extends http.Agent {
     return this.#getProxyForUrl(url, request);
   }
 
-  #isSecureEndpoint(): boolean {
+  #isHttpsCallStack(): boolean {
     const stack = new Error().stack;
     if (typeof stack !== "string") {
       return false;
@@ -576,8 +584,10 @@ export class ProxylineNodeProxyAgent extends http.Agent {
 export function createNodeProxyAgent(
   resolver: ProxyResolver,
   proxyCa: string | undefined,
+  defaultProtocol: "http" | "https" = "http",
 ): ProxylineNodeProxyAgent {
   return new ProxylineNodeProxyAgent({
+    defaultProtocol,
     getProxyForUrl: resolver.getProxyForUrl,
     ...(proxyCa !== undefined ? { proxyTls: { ca: proxyCa } } : {}),
   });
@@ -592,6 +602,7 @@ export function createDirectNodeAgent(): ProxylineNodeProxyAgent {
 export type AmbientNodeProxyAgentOptions = {
   env?: ProxyEnvSnapshot;
   protocol?: "http" | "https";
+  proxyTls?: ProxylineTlsOptions;
 };
 
 function ambientProbeUrl(protocol: "http" | "https"): string {
@@ -615,6 +626,8 @@ export function createAmbientNodeProxyAgent(
     return undefined;
   }
   return new ProxylineNodeProxyAgent({
+    defaultProtocol: protocol,
     getProxyForUrl: (url) => resolveAmbientProxyForUrl(url, env) ?? "",
+    ...(options.proxyTls !== undefined ? { proxyTls: options.proxyTls } : {}),
   });
 }

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import https from "node:https";
 import net from "node:net";
 import tls from "node:tls";
+import { domainToASCII } from "node:url";
 import {
   readProxyEnv,
   resolveAmbientProxyForUrl,
@@ -253,7 +254,7 @@ function normalizedPositiveInteger(value: unknown): number | undefined {
 function requestAuthority(options: NodeAgentRequestOptions): string {
   const rawHost = options.hostname ?? options.host ?? "localhost";
   const parsed = splitHostPort(String(rawHost));
-  const host = parsed.host || "localhost";
+  const host = normalizeProxyTargetHost(parsed.host || "localhost");
   const port = parsed.port ?? normalizedPort(options.port);
   const authorityHost = net.isIPv6(host) ? `[${host}]` : host;
   return port === undefined ? authorityHost : `${authorityHost}:${port}`;
@@ -343,6 +344,19 @@ function splitHostPort(value: string): { host: string; port?: number } {
   return { host: value };
 }
 
+function normalizeProxyTargetHost(host: string): string {
+  const unbracketedHost =
+    host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  if (net.isIP(unbracketedHost) !== 0) {
+    return unbracketedHost;
+  }
+  const asciiHost = domainToASCII(host);
+  if (!asciiHost) {
+    throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target host is not a valid host name.");
+  }
+  return asciiHost;
+}
+
 function connectTarget(options: NodeAgentRequestOptions): { host: string; port: number } {
   const rawHost = options.hostname ?? options.host;
   if (typeof rawHost !== "string") {
@@ -353,8 +367,9 @@ function connectTarget(options: NodeAgentRequestOptions): { host: string; port: 
   if (!parsed.host || !Number.isInteger(port)) {
     throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target is missing host or port.");
   }
-  formatConnectAuthority(parsed.host, port);
-  return { host: parsed.host, port };
+  const host = normalizeProxyTargetHost(parsed.host);
+  formatConnectAuthority(host, port);
+  return { host, port };
 }
 
 function destinationTlsConnectOptions(

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -265,7 +265,7 @@ function requestUrl(
   options: NodeAgentRequestOptions,
   stackProtocol: "http" | "https" | undefined,
 ): string {
-  if (/^(?:https?|wss?):\/\//i.test(req.path)) {
+  if (!shouldTunnelRequest(req, options, stackProtocol) && /^(?:https?|wss?):\/\//i.test(req.path)) {
     return new URL(req.path).href;
   }
   const path = req.path.startsWith("/") ? req.path : `/${req.path}`;
@@ -500,6 +500,13 @@ class ProxylineConnectAgent extends http.Agent {
       pendingTimeout.unref?.();
     };
 
+    const clearPendingTimeout = (): void => {
+      if (pendingTimeout !== undefined) {
+        clearTimeout(pendingTimeout);
+        pendingTimeout = undefined;
+      }
+    };
+
     const restoreRequestTimeoutHook = (): void => {
       if (
         request !== undefined &&
@@ -522,10 +529,7 @@ class ProxylineConnectAgent extends http.Agent {
     };
 
     const cleanup = (): void => {
-      if (pendingTimeout !== undefined) {
-        clearTimeout(pendingTimeout);
-        pendingTimeout = undefined;
-      }
+      clearPendingTimeout();
       this.#pendingConnectSockets.delete(proxySocket);
       if (tlsSocket !== undefined) {
         this.#pendingConnectSockets.delete(tlsSocket);
@@ -646,6 +650,8 @@ class ProxylineConnectAgent extends http.Agent {
         const timeoutMs = normalizedPositiveInteger(timeout);
         if (timeoutMs !== undefined) {
           startPendingTimeout(timeoutMs);
+        } else {
+          clearPendingTimeout();
         }
         return result;
       };

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -41,6 +41,7 @@ type NodeProxyAgentOptions = NodeAgentOptions & {
 
 const MAX_CONNECT_RESPONSE_HEADER_BYTES = 16 * 1024;
 const INVALID_PROXY_TARGET_HOST_DELIMITER_PATTERN = /[/:?#@\\]/;
+const INVALID_PROXY_TARGET_HOST_CONTROL_PATTERN = /[\u0000-\u0020\u007f]/;
 const nodeAgentDefaultPorts = new WeakMap<object, number>();
 
 export const CALLER_AGENT_TLS_OPTION_KEYS = [
@@ -357,6 +358,9 @@ function normalizeProxyTargetHost(host: string): string {
   }
   if (INVALID_PROXY_TARGET_HOST_DELIMITER_PATTERN.test(host)) {
     throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target host contains unsafe delimiters.");
+  }
+  if (INVALID_PROXY_TARGET_HOST_CONTROL_PATTERN.test(host)) {
+    throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target host contains unsafe characters.");
   }
   const asciiHost = domainToASCII(host);
   if (!asciiHost) {

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -632,7 +632,17 @@ export class ProxylineNodeProxyAgent extends http.Agent {
   }
 
   #callStackProtocol(): "http" | "https" | undefined {
-    const stack = new Error().stack;
+    const originalStackTraceLimit = Error.stackTraceLimit;
+    if (typeof originalStackTraceLimit === "number" && originalStackTraceLimit < 20) {
+      // Node reads agent.protocol/defaultPort before addRequest, so this is the only caller signal.
+      Error.stackTraceLimit = 20;
+    }
+    let stack: string | undefined;
+    try {
+      stack = new Error().stack;
+    } finally {
+      Error.stackTraceLimit = originalStackTraceLimit;
+    }
     if (typeof stack !== "string") {
       return undefined;
     }

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -7,6 +7,7 @@ import {
   resolveAmbientProxyForUrl,
   type ProxyEnvSnapshot,
 } from "./env.js";
+import { formatConnectAuthority } from "./connect.js";
 import { ProxylineError, resolveProxyTlsCa, type ProxylineTlsOptions } from "./shared.js";
 import type { ProxyResolver } from "./types.js";
 
@@ -349,9 +350,10 @@ function connectTarget(options: NodeAgentRequestOptions): { host: string; port: 
   }
   const parsed = splitHostPort(rawHost);
   const port = parsed.port ?? Number(options.port);
-  if (!parsed.host || !Number.isInteger(port) || port < 1 || port > 65_535) {
+  if (!parsed.host || !Number.isInteger(port)) {
     throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target is missing host or port.");
   }
+  formatConnectAuthority(parsed.host, port);
   return { host: parsed.host, port };
 }
 
@@ -541,7 +543,7 @@ class ProxylineConnectAgent extends http.Agent {
         return;
       }
       const { host, port } = target;
-      const authority = net.isIPv6(host) ? `[${host}]:${port}` : `${host}:${port}`;
+      const authority = formatConnectAuthority(host, port);
       const headers = [
         `CONNECT ${authority} HTTP/1.1`,
         `Host: ${authority}`,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,5 @@
 import http from "node:http";
 import https from "node:https";
-import { ProxyAgent as NodeProxyAgent } from "proxy-agent";
 import {
   Agent as UndiciAgent,
   Dispatcher,
@@ -26,6 +25,7 @@ import {
   createDirectNodeAgent,
   createNodeProxyAgent,
   type NodeHttpStackSnapshot,
+  type ProxylineNodeProxyAgent,
 } from "./node-http.js";
 import {
   formatUrl,
@@ -45,7 +45,7 @@ import type {
 type RuntimeInstall = {
   installedDispatcher: Dispatcher;
   mode: ProxylineOptions["mode"];
-  nodeAgent: NodeProxyAgent;
+  nodeAgent: ProxylineNodeProxyAgent;
   originalDispatcher: Dispatcher;
   originalFetch: typeof globalThis.fetch;
   originalFormData: typeof globalThis.FormData;
@@ -573,7 +573,7 @@ function installRuntime(
   activeRuntime = runtime;
   try {
     http.globalAgent = nodeAgent;
-    https.globalAgent = nodeAgent;
+    https.globalAgent = nodeAgent as unknown as typeof https.globalAgent;
     http.request = bindNodeHttpMethod(snapshot.httpRequest, () =>
       createNodeProxyAgent(resolver, proxyCa),
     );

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -45,7 +45,8 @@ import type {
 type RuntimeInstall = {
   installedDispatcher: Dispatcher;
   mode: ProxylineOptions["mode"];
-  nodeAgent: ProxylineNodeProxyAgent;
+  nodeHttpAgent: ProxylineNodeProxyAgent;
+  nodeHttpsAgent: ProxylineNodeProxyAgent;
   originalDispatcher: Dispatcher;
   originalFetch: typeof globalThis.fetch;
   originalFormData: typeof globalThis.FormData;
@@ -550,7 +551,8 @@ function installRuntime(
     httpsGet: https.get,
     httpsGlobalAgent: https.globalAgent,
   };
-  const nodeAgent = createNodeProxyAgent(resolver, proxyCa);
+  const nodeHttpAgent = createNodeProxyAgent(resolver, proxyCa, "http");
+  const nodeHttpsAgent = createNodeProxyAgent(resolver, proxyCa, "https");
   const originalDispatcher = getGlobalDispatcher();
   const originalFetch = globalThis.fetch;
   const originalFormData = globalThis.FormData;
@@ -561,7 +563,8 @@ function installRuntime(
   const runtime: RuntimeInstall = {
     installedDispatcher,
     mode: dispatcherOptions.mode,
-    nodeAgent,
+    nodeHttpAgent,
+    nodeHttpsAgent,
     originalDispatcher,
     originalFetch,
     originalFormData,
@@ -572,19 +575,19 @@ function installRuntime(
   };
   activeRuntime = runtime;
   try {
-    http.globalAgent = nodeAgent;
-    https.globalAgent = nodeAgent as unknown as typeof https.globalAgent;
+    http.globalAgent = nodeHttpAgent;
+    https.globalAgent = nodeHttpsAgent as unknown as typeof https.globalAgent;
     http.request = bindNodeHttpMethod(snapshot.httpRequest, () =>
-      createNodeProxyAgent(resolver, proxyCa),
+      createNodeProxyAgent(resolver, proxyCa, "http"),
     );
     http.get = bindNodeHttpMethod(snapshot.httpGet, () =>
-      createNodeProxyAgent(resolver, proxyCa),
+      createNodeProxyAgent(resolver, proxyCa, "http"),
     );
     https.request = bindNodeHttpMethod(snapshot.httpsRequest, () =>
-      createNodeProxyAgent(resolver, proxyCa),
+      createNodeProxyAgent(resolver, proxyCa, "https"),
     );
     https.get = bindNodeHttpMethod(snapshot.httpsGet, () =>
-      createNodeProxyAgent(resolver, proxyCa),
+      createNodeProxyAgent(resolver, proxyCa, "https"),
     );
     setGlobalDispatcher(installedDispatcher);
     globalThis.fetch = proxylineFetch;
@@ -602,7 +605,8 @@ function installRuntime(
     globalThis.Response = originalResponse;
     activeRuntime = undefined;
     void installedDispatcher.destroy();
-    nodeAgent.destroy();
+    nodeHttpAgent.destroy();
+    nodeHttpsAgent.destroy();
     throw error;
   }
   return runtime;
@@ -620,7 +624,8 @@ function stopRuntime(runtime: RuntimeInstall): void {
   globalThis.Request = runtime.originalRequest;
   globalThis.Response = runtime.originalResponse;
   void runtime.installedDispatcher.destroy();
-  runtime.nodeAgent.destroy();
+  runtime.nodeHttpAgent.destroy();
+  runtime.nodeHttpsAgent.destroy();
   activeRuntime = undefined;
 }
 

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -3,6 +3,7 @@ import { once } from "node:events";
 import http from "node:http";
 import https from "node:https";
 import { type AddressInfo } from "node:net";
+import { type Duplex } from "node:stream";
 import { URL } from "node:url";
 import test from "node:test";
 import { Dispatcher, fetch } from "undici";
@@ -176,6 +177,56 @@ test("ambient mode routes node:http through HTTP_PROXY", async () => {
   }
 });
 
+test("managed mode evaluates node:http proxy policy against the socket destination", async () => {
+  const lab = await startProxyLab();
+  const targetUrl = new URL(lab.targetUrl);
+  const proxy = installGlobalProxy({
+    mode: "managed",
+    proxyUrl: lab.proxyUrl,
+    bypassPolicy: ({ url }) => new URL(url).hostname === "localhost",
+  });
+  try {
+    const denied = await readHttpOptions({
+      headers: { host: "localhost" },
+      hostname: targetUrl.hostname,
+      path: "/denied",
+      port: targetUrl.port,
+      protocol: "http:",
+    });
+
+    assert.equal(denied.status, 403);
+    assert.match(denied.body, /blocked by proxy lab/);
+    assert.ok(lab.events.some((event) => event.type === "deny" && event.url.endsWith("/denied")));
+  } finally {
+    proxy.stop();
+    await lab.close();
+  }
+});
+
+test("managed mode preserves origin-form paths that start with double slash", async () => {
+  const lab = await startProxyLab();
+  const targetUrl = new URL(lab.targetUrl);
+  const proxy = installGlobalProxy({ mode: "managed", proxyUrl: lab.proxyUrl });
+  try {
+    const response = await readHttpOptions({
+      hostname: targetUrl.hostname,
+      path: "//double",
+      port: targetUrl.port,
+      protocol: "http:",
+    });
+
+    assert.equal(response.status, 200);
+    assert.ok(
+      lab.events.some(
+        (event) => event.type === "request" && event.url === `${lab.targetUrl}//double`,
+      ),
+    );
+  } finally {
+    proxy.stop();
+    await lab.close();
+  }
+});
+
 test("ambient mode preserves absolute-form HTTPS request paths on node:http", async () => {
   const lab = await startProxyLab();
   const proxy = withProxyEnv({ HTTPS_PROXY: lab.proxyUrl }, () =>
@@ -236,6 +287,51 @@ test("managed mode uses port 443 for default-port node:https CONNECT targets", a
       proxy.stop();
     }
   });
+});
+
+test("managed mode times out stalled node:https CONNECT handshakes", async () => {
+  const proxyServer = http.createServer();
+  const activeSockets = new Set<Duplex>();
+  const allSockets = new Set<Duplex>();
+  proxyServer.on("connect", (_req, socket) => {
+    activeSockets.add(socket);
+    allSockets.add(socket);
+    socket.once("end", () => {
+      activeSockets.delete(socket);
+    });
+    socket.once("close", () => {
+      activeSockets.delete(socket);
+      allSockets.delete(socket);
+    });
+  });
+  proxyServer.listen(0, "127.0.0.1");
+  await once(proxyServer, "listening");
+  const address = proxyServer.address() as AddressInfo;
+  const proxy = installGlobalProxy({
+    mode: "managed",
+    proxyUrl: `http://127.0.0.1:${address.port}`,
+  });
+  try {
+    await assert.rejects(readHttps("https://example.test/allowed", { timeout: 50 }), /timed out/);
+    for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(activeSockets.size, 0);
+  } finally {
+    proxy.stop();
+    for (const socket of allSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve, reject) => {
+      proxyServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
 });
 
 test("ambient Node proxy helper trusts HTTPS proxy endpoints with scoped proxy TLS", async () => {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -557,6 +557,42 @@ test("managed mode honors req.setTimeout during stalled node:https CONNECT hands
   });
 });
 
+test("node CONNECT agent destroys pending proxy sockets when the agent is destroyed", async () => {
+  await withStalledConnectProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "https");
+    const req = https.get("https://example.test/allowed", { agent }, () => {});
+    const requestClosed = new Promise<void>((resolve) => {
+      req.once("error", () => resolve());
+      req.once("close", () => resolve());
+    });
+    try {
+      for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 1);
+
+      agent.destroy();
+
+      for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
+      await requestClosed;
+    } finally {
+      req.destroy();
+      agent.destroy();
+    }
+  });
+});
+
 test("node CONNECT agent detaches its parser before destination TLS", async () => {
   const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
   const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -8,7 +8,11 @@ import test from "node:test";
 import { Dispatcher, fetch } from "undici";
 import WebSocket from "ws";
 import { createWebSocketServer } from "./support/ws-server.js";
-import { installGlobalProxy, openProxyConnectTunnel } from "../src/index.js";
+import {
+  createAmbientNodeProxyAgent,
+  installGlobalProxy,
+  openProxyConnectTunnel,
+} from "../src/index.js";
 import { startProxyLab } from "./support/proxy-lab.js";
 
 function withProxyEnv<T>(env: Record<string, string | undefined>, run: () => T): T {
@@ -122,6 +126,33 @@ async function readHttpsOptions(
   });
 }
 
+async function withConnectRecorder<T>(
+  run: (proxyUrl: string, authorities: string[]) => Promise<T>,
+): Promise<T> {
+  const authorities: string[] = [];
+  const proxy = http.createServer();
+  proxy.on("connect", (req, socket) => {
+    authorities.push(req.url ?? "");
+    socket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
+  });
+  proxy.listen(0, "127.0.0.1");
+  await once(proxy, "listening");
+  const address = proxy.address() as AddressInfo;
+  try {
+    return await run(`http://127.0.0.1:${address.port}`, authorities);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      proxy.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
 test("ambient mode routes node:http through HTTP_PROXY", async () => {
   const lab = await startProxyLab();
   const proxy = withProxyEnv({ HTTP_PROXY: lab.proxyUrl }, () =>
@@ -191,6 +222,46 @@ test("ambient mode routes node:https through HTTPS_PROXY", async () => {
     assert.ok(lab.events.some((event) => event.type === "connect"));
   } finally {
     proxy.stop();
+    await lab.close();
+  }
+});
+
+test("managed mode uses port 443 for default-port node:https CONNECT targets", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const proxy = installGlobalProxy({ mode: "managed", proxyUrl });
+    try {
+      await assert.rejects(readHttps("https://example.test/allowed", { timeout: 1_000 }));
+      assert.deepEqual(authorities, ["example.test:443"]);
+    } finally {
+      proxy.stop();
+    }
+  });
+});
+
+test("ambient Node proxy helper trusts HTTPS proxy endpoints with scoped proxy TLS", async () => {
+  const lab = await startProxyLab({ secureProxy: true, secureTarget: true });
+  const proxyCa = lab.proxyCa;
+  const targetCa = lab.targetCa;
+  assert.ok(proxyCa);
+  assert.ok(targetCa);
+  const agent = withProxyEnv({ HTTPS_PROXY: lab.proxyUrl }, () =>
+    createAmbientNodeProxyAgent({
+      protocol: "https",
+      proxyTls: { ca: proxyCa },
+    }),
+  );
+  try {
+    assert.ok(agent);
+    const allowed = await readHttps(`${lab.targetUrl}/allowed`, {
+      agent,
+      ca: targetCa,
+    });
+
+    assert.equal(allowed.status, 200);
+    assert.equal(allowed.body, "allowed via target\n");
+    assert.ok(lab.events.some((event) => event.type === "connect"));
+  } finally {
+    agent?.destroy();
     await lab.close();
   }
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -739,6 +739,59 @@ test("node CONNECT agent destroys pending proxy sockets when the agent is destro
   });
 });
 
+test("node CONNECT agent fails requests when destination TLS closes during handshake", async () => {
+  const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
+  const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };
+  const originalNetConnect = netMutable.connect;
+  const originalTlsConnect = tlsMutable.connect;
+  let tlsSocket: FakeProxySocket | undefined;
+  const resolver: ProxyResolver = {
+    active: true,
+    describeProxy: () => "http://proxy.example:8080/",
+    explain: () => {
+      throw new Error("not used");
+    },
+    getProxyForUrl: () => "http://proxy.example:8080/",
+  };
+  const agent = createNodeProxyAgent(resolver, undefined, "https");
+  try {
+    netMutable.connect = () => {
+      const proxySocket = new FakeProxySocket();
+      queueMicrotask(() => proxySocket.emit("connect"));
+      return proxySocket as unknown as net.Socket;
+    };
+    tlsMutable.connect = () => {
+      tlsSocket = new FakeProxySocket();
+      return tlsSocket as unknown as tls.TLSSocket;
+    };
+
+    const requestError = new Promise<Error>((resolve) => {
+      const req = https.get("https://example.test/", { agent }, () => {});
+      req.once("error", resolve);
+    });
+    for (let attempt = 0; attempt < 20 && tlsSocket === undefined; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.ok(tlsSocket);
+
+    agent.destroy();
+
+    await assert.rejects(
+      Promise.race([
+        requestError.then((error) => {
+          throw error;
+        }),
+        new Promise<void>((resolve) => setTimeout(resolve, 500)),
+      ]),
+      /destination TLS socket closed/,
+    );
+  } finally {
+    netMutable.connect = originalNetConnect;
+    tlsMutable.connect = originalTlsConnect;
+    agent.destroy();
+  }
+});
+
 test("node CONNECT agent detaches its parser before destination TLS", async () => {
   const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
   const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -266,6 +266,28 @@ test("ambient Node proxy helper trusts HTTPS proxy endpoints with scoped proxy T
   }
 });
 
+test("ambient Node proxy helper routes HTTP callers even when probing HTTPS by default", async () => {
+  const lab = await startProxyLab();
+  const agent = withProxyEnv(
+    {
+      HTTP_PROXY: lab.proxyUrl,
+      HTTPS_PROXY: "http://127.0.0.1:9",
+    },
+    () => createAmbientNodeProxyAgent(),
+  );
+  try {
+    assert.ok(agent);
+    const denied = await readHttp(`${lab.targetUrl}/denied`, agent);
+
+    assert.equal(denied.status, 403);
+    assert.match(denied.body, /blocked by proxy lab/);
+    assert.ok(lab.events.some((event) => event.type === "deny"));
+  } finally {
+    agent?.destroy();
+    await lab.close();
+  }
+});
+
 test("ambient mode defaults bare HTTPS_PROXY endpoints to HTTP proxy URLs", async () => {
   const lab = await startProxyLab({ secureTarget: true });
   assert.ok(lab.targetCa);

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -294,9 +294,9 @@ test("managed mode preserves origin-form paths that start with double slash", as
   }
 });
 
-test("ambient mode preserves absolute-form HTTPS request paths on node:http", async () => {
+test("ambient mode preserves absolute-form HTTPS request paths on proxied node:http", async () => {
   const lab = await startProxyLab();
-  const proxy = withProxyEnv({ HTTPS_PROXY: lab.proxyUrl }, () =>
+  const proxy = withProxyEnv({ HTTP_PROXY: lab.proxyUrl }, () =>
     installGlobalProxy({ mode: "ambient" }),
   );
   try {
@@ -318,6 +318,28 @@ test("ambient mode preserves absolute-form HTTPS request paths on node:http", as
         (event) => event.type === "request" && event.url.includes("http://api.example.testhttps://"),
       ),
     );
+  } finally {
+    proxy.stop();
+    await lab.close();
+  }
+});
+
+test("managed mode evaluates absolute-form node:http proxy policy against the socket destination", async () => {
+  const lab = await startProxyLab();
+  const proxy = installGlobalProxy({
+    mode: "managed",
+    proxyUrl: lab.proxyUrl,
+    bypassPolicy: ({ url }) => new URL(url).hostname === "localhost",
+  });
+  try {
+    const response = await readHttpOptions({
+      hostname: "evil.example",
+      path: "http://localhost/denied",
+      protocol: "http:",
+    });
+
+    assert.equal(response.status, 403);
+    assert.ok(lab.events.some((event) => event.type === "deny" && event.url === "http://localhost/denied"));
   } finally {
     proxy.stop();
     await lab.close();
@@ -400,6 +422,35 @@ test("node CONNECT agents reject unsafe object-form HTTPS hosts before proxying"
           agent,
           headers: { host: "safe.example" },
           hostname: "evil.example\r\nProxy-Authorization: injected",
+          path: "/allowed",
+          timeout: 1_000,
+        }),
+        (error: unknown) =>
+          error instanceof ProxylineError && error.code === "INVALID_CONNECT_TARGET",
+      );
+      assert.deepEqual(authorities, []);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
+test("node CONNECT agents reject delimiter-truncated object-form HTTPS hosts", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    try {
+      await assert.rejects(
+        readHttpsOptions({
+          agent,
+          hostname: "evil.example/path",
           path: "/allowed",
           timeout: 1_000,
         }),

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -101,6 +101,27 @@ async function readHttps(
   });
 }
 
+async function readHttpsOptions(
+  options: https.RequestOptions,
+): Promise<{ status: number; body: string }> {
+  return await new Promise((resolve, reject) => {
+    const req = https.get({ ...options, timeout: options.timeout ?? 2_000 }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        resolve({ status: res.statusCode ?? 0, body });
+      });
+    });
+    req.on("timeout", () => {
+      req.destroy(new Error(`HTTPS request timed out for ${String(options.host ?? options.hostname)}`));
+    });
+    req.on("error", reject);
+  });
+}
+
 test("ambient mode routes node:http through HTTP_PROXY", async () => {
   const lab = await startProxyLab();
   const proxy = withProxyEnv({ HTTP_PROXY: lab.proxyUrl }, () =>
@@ -192,6 +213,30 @@ test("ambient mode defaults bare HTTPS_PROXY endpoints to HTTP proxy URLs", asyn
     assert.equal(decision.kind, "proxied");
     assert.equal(decision.proxyUrl, lab.proxyUrl + "/");
     assert.ok(lab.events.some((event) => event.type === "connect"));
+  } finally {
+    proxy.stop();
+    await lab.close();
+  }
+});
+
+test("ambient mode parses host-header ports for node:https CONNECT targets", async () => {
+  const lab = await startProxyLab({ secureTarget: true });
+  assert.ok(lab.targetCa);
+  const target = new URL(lab.targetUrl);
+  const proxy = withProxyEnv({ HTTPS_PROXY: lab.proxyUrl }, () =>
+    installGlobalProxy({ mode: "ambient" }),
+  );
+  try {
+    const allowed = await readHttpsOptions({
+      protocol: "https:",
+      host: target.host,
+      path: "/allowed",
+      ca: lab.targetCa,
+    });
+
+    assert.equal(allowed.status, 200);
+    assert.equal(allowed.body, "allowed via target\n");
+    assert.ok(lab.events.some((event) => event.type === "connect" && event.authority === target.host));
   } finally {
     proxy.stop();
     await lab.close();

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -355,6 +355,33 @@ test("managed mode uses port 443 for default-port node:https CONNECT targets", a
   });
 });
 
+test("node helper agents route object-form HTTPS requests as secure endpoints", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    try {
+      await assert.rejects(
+        readHttpsOptions({
+          agent,
+          hostname: "example.test",
+          path: "/allowed",
+          timeout: 1_000,
+        }),
+      );
+      assert.deepEqual(authorities, ["example.test:443"]);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
 test("node helper agents infer default HTTPS ports with stack traces disabled", async () => {
   await withConnectRecorder(async (proxyUrl, authorities) => {
     const resolver: ProxyResolver = {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -156,6 +156,44 @@ async function withConnectRecorder<T>(
   }
 }
 
+async function withStalledConnectProxy<T>(
+  run: (proxyUrl: string, activeSockets: Set<Duplex>) => Promise<T>,
+): Promise<T> {
+  const proxyServer = http.createServer();
+  const activeSockets = new Set<Duplex>();
+  const allSockets = new Set<Duplex>();
+  proxyServer.on("connect", (_req, socket) => {
+    activeSockets.add(socket);
+    allSockets.add(socket);
+    socket.once("end", () => {
+      activeSockets.delete(socket);
+    });
+    socket.once("close", () => {
+      activeSockets.delete(socket);
+      allSockets.delete(socket);
+    });
+  });
+  proxyServer.listen(0, "127.0.0.1");
+  await once(proxyServer, "listening");
+  const address = proxyServer.address() as AddressInfo;
+  try {
+    return await run(`http://127.0.0.1:${address.port}`, activeSockets);
+  } finally {
+    for (const socket of allSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve, reject) => {
+      proxyServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
 test("ambient mode routes node:http through HTTP_PROXY", async () => {
   const lab = await startProxyLab();
   const proxy = withProxyEnv({ HTTP_PROXY: lab.proxyUrl }, () =>
@@ -314,49 +352,74 @@ test("node helper agents infer default HTTPS ports with stack traces disabled", 
   });
 });
 
+test("node helper agents infer default HTTPS ports with custom stack formatters", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    const originalPrepareStackTrace = Error.prepareStackTrace;
+    Error.prepareStackTrace = () => [];
+    try {
+      await assert.rejects(readHttps("https://example.test/allowed", { agent, timeout: 1_000 }));
+      assert.deepEqual(authorities, ["example.test:443"]);
+    } finally {
+      Error.prepareStackTrace = originalPrepareStackTrace;
+      agent.destroy();
+    }
+  });
+});
+
 test("managed mode times out stalled node:https CONNECT handshakes", async () => {
-  const proxyServer = http.createServer();
-  const activeSockets = new Set<Duplex>();
-  const allSockets = new Set<Duplex>();
-  proxyServer.on("connect", (_req, socket) => {
-    activeSockets.add(socket);
-    allSockets.add(socket);
-    socket.once("end", () => {
-      activeSockets.delete(socket);
+  await withStalledConnectProxy(async (proxyUrl, activeSockets) => {
+    const proxy = installGlobalProxy({
+      mode: "managed",
+      proxyUrl,
     });
-    socket.once("close", () => {
-      activeSockets.delete(socket);
-      allSockets.delete(socket);
-    });
-  });
-  proxyServer.listen(0, "127.0.0.1");
-  await once(proxyServer, "listening");
-  const address = proxyServer.address() as AddressInfo;
-  const proxy = installGlobalProxy({
-    mode: "managed",
-    proxyUrl: `http://127.0.0.1:${address.port}`,
-  });
-  try {
-    await assert.rejects(readHttps("https://example.test/allowed", { timeout: 50 }), /timed out/);
-    for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 25));
+    try {
+      await assert.rejects(readHttps("https://example.test/allowed", { timeout: 50 }), /timed out/);
+      for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
+    } finally {
+      proxy.stop();
     }
-    assert.equal(activeSockets.size, 0);
-  } finally {
-    proxy.stop();
-    for (const socket of allSockets) {
-      socket.destroy();
-    }
-    await new Promise<void>((resolve, reject) => {
-      proxyServer.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        resolve();
-      });
+  });
+});
+
+test("managed mode honors req.setTimeout during stalled node:https CONNECT handshakes", async () => {
+  await withStalledConnectProxy(async (proxyUrl, activeSockets) => {
+    const proxy = installGlobalProxy({
+      mode: "managed",
+      proxyUrl,
     });
-  }
+    try {
+      await assert.rejects(
+        new Promise<void>((resolve, reject) => {
+          const req = https.get("https://example.test/allowed", () => {
+            resolve();
+          });
+          req.setTimeout(50, () => {
+            req.destroy(new Error("late request timeout"));
+          });
+          req.on("error", reject);
+        }),
+        /timeout|timed out/,
+      );
+      for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
+    } finally {
+      proxy.stop();
+    }
+  });
 });
 
 test("ambient Node proxy helper trusts HTTPS proxy endpoints with scoped proxy TLS", async () => {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -14,6 +14,7 @@ import {
   createAmbientNodeProxyAgent,
   installGlobalProxy,
   openProxyConnectTunnel,
+  ProxylineError,
 } from "../src/index.js";
 import { createNodeProxyAgent } from "../src/node-http.js";
 import type { ProxyResolver } from "../src/types.js";
@@ -376,6 +377,36 @@ test("node helper agents route object-form HTTPS requests as secure endpoints", 
         }),
       );
       assert.deepEqual(authorities, ["example.test:443"]);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
+test("node CONNECT agents reject unsafe object-form HTTPS hosts before proxying", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    try {
+      await assert.rejects(
+        readHttpsOptions({
+          agent,
+          headers: { host: "safe.example" },
+          hostname: "evil.example\r\nProxy-Authorization: injected",
+          path: "/allowed",
+          timeout: 1_000,
+        }),
+        (error: unknown) =>
+          error instanceof ProxylineError && error.code === "INVALID_CONNECT_TARGET",
+      );
+      assert.deepEqual(authorities, []);
     } finally {
       agent.destroy();
     }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -464,6 +464,35 @@ test("node CONNECT agents reject delimiter-truncated object-form HTTPS hosts", a
   });
 });
 
+test("node CONNECT agents reject control-truncated object-form HTTPS hosts", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    try {
+      await assert.rejects(
+        readHttpsOptions({
+          agent,
+          hostname: "evil\thost.example",
+          path: "/allowed",
+          timeout: 1_000,
+        }),
+        (error: unknown) =>
+          error instanceof ProxylineError && error.code === "INVALID_CONNECT_TARGET",
+      );
+      assert.deepEqual(authorities, []);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
 test("node CONNECT agents encode object-form HTTPS Unicode hosts", async () => {
   await withConnectRecorder(async (proxyUrl, authorities) => {
     const resolver: ProxyResolver = {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -413,6 +413,33 @@ test("node CONNECT agents reject unsafe object-form HTTPS hosts before proxying"
   });
 });
 
+test("node CONNECT agents encode object-form HTTPS Unicode hosts", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    try {
+      await assert.rejects(
+        readHttpsOptions({
+          agent,
+          hostname: "bücher.example",
+          path: "/allowed",
+          timeout: 1_000,
+        }),
+      );
+      assert.deepEqual(authorities, ["xn--bcher-kva.example:443"]);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
 test("node helper agents infer default HTTPS ports with stack traces disabled", async () => {
   await withConnectRecorder(async (proxyUrl, authorities) => {
     const resolver: ProxyResolver = {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -14,6 +14,8 @@ import {
   installGlobalProxy,
   openProxyConnectTunnel,
 } from "../src/index.js";
+import { createNodeProxyAgent } from "../src/node-http.js";
+import type { ProxyResolver } from "../src/types.js";
 import { startProxyLab } from "./support/proxy-lab.js";
 
 function withProxyEnv<T>(env: Record<string, string | undefined>, run: () => T): T {
@@ -285,6 +287,29 @@ test("managed mode uses port 443 for default-port node:https CONNECT targets", a
       assert.deepEqual(authorities, ["example.test:443"]);
     } finally {
       proxy.stop();
+    }
+  });
+});
+
+test("node helper agents infer default HTTPS ports with stack traces disabled", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    const originalStackTraceLimit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 0;
+    try {
+      await assert.rejects(readHttps("https://example.test/allowed", { agent, timeout: 1_000 }));
+      assert.deepEqual(authorities, ["example.test:443"]);
+    } finally {
+      Error.stackTraceLimit = originalStackTraceLimit;
+      agent.destroy();
     }
   });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -440,6 +440,38 @@ test("node CONNECT agents encode object-form HTTPS Unicode hosts", async () => {
   });
 });
 
+test("node CONNECT agents ignore absolute-form paths for secure proxy decisions", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const seenUrls: string[] = [];
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: (url) => {
+        seenUrls.push(url);
+        return new URL(url).hostname === "bypass.example" ? "" : proxyUrl;
+      },
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "https");
+    try {
+      await assert.rejects(
+        readHttpsOptions({
+          agent,
+          hostname: "real.example",
+          path: "https://bypass.example/secret",
+          timeout: 1_000,
+        }),
+      );
+      assert.equal(new URL(seenUrls[0] ?? "").hostname, "real.example");
+      assert.deepEqual(authorities, ["real.example:443"]);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
 test("node helper agents infer default HTTPS ports with stack traces disabled", async () => {
   await withConnectRecorder(async (proxyUrl, authorities) => {
     const resolver: ProxyResolver = {
@@ -553,6 +585,40 @@ test("managed mode honors req.setTimeout during stalled node:https CONNECT hands
       assert.equal(activeSockets.size, 0);
     } finally {
       proxy.stop();
+    }
+  });
+});
+
+test("node CONNECT agent clears pending timeouts when req.setTimeout disables them", async () => {
+  await withStalledConnectProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "https");
+    const req = https.get("https://example.test/allowed", { agent, timeout: 50 }, () => {});
+    let requestError: Error | undefined;
+    req.on("error", (error) => {
+      requestError = error;
+    });
+    try {
+      req.setTimeout(0);
+      for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 1);
+
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      assert.equal(requestError, undefined);
+      assert.equal(activeSockets.size, 1);
+    } finally {
+      req.destroy();
+      agent.destroy();
     }
   });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import { once } from "node:events";
 import http from "node:http";
 import https from "node:https";
-import { type AddressInfo } from "node:net";
-import { type Duplex } from "node:stream";
+import net, { type AddressInfo } from "node:net";
+import { Duplex } from "node:stream";
+import tls from "node:tls";
 import { URL } from "node:url";
 import test from "node:test";
 import { Dispatcher, fetch } from "undici";
@@ -194,6 +195,31 @@ async function withStalledConnectProxy<T>(
   }
 }
 
+class FakeProxySocket extends Duplex {
+  public override _read(): void {}
+
+  public override _write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    if (chunk.toString("latin1").startsWith("CONNECT ")) {
+      queueMicrotask(() => {
+        this.emit("data", Buffer.from("HTTP/1.1 200 Connection Established\r\n\r\n"));
+      });
+    }
+    callback();
+  }
+
+  public setNoDelay(): this {
+    return this;
+  }
+
+  public setKeepAlive(): this {
+    return this;
+  }
+
+  public setTimeout(): this {
+    return this;
+  }
+}
+
 test("ambient mode routes node:http through HTTP_PROXY", async () => {
   const lab = await startProxyLab();
   const proxy = withProxyEnv({ HTTP_PROXY: lab.proxyUrl }, () =>
@@ -352,6 +378,30 @@ test("node helper agents infer default HTTPS ports with stack traces disabled", 
   });
 });
 
+test("node helper agents infer default HTTPS ports with non-number stack trace limits", async () => {
+  await withConnectRecorder(async (proxyUrl, authorities) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined);
+    const errorConstructor = Error as unknown as { stackTraceLimit: unknown };
+    const originalStackTraceLimit = errorConstructor.stackTraceLimit;
+    errorConstructor.stackTraceLimit = undefined;
+    try {
+      await assert.rejects(readHttps("https://example.test/allowed", { agent, timeout: 1_000 }));
+      assert.deepEqual(authorities, ["example.test:443"]);
+    } finally {
+      errorConstructor.stackTraceLimit = originalStackTraceLimit;
+      agent.destroy();
+    }
+  });
+});
+
 test("node helper agents infer default HTTPS ports with custom stack formatters", async () => {
   await withConnectRecorder(async (proxyUrl, authorities) => {
     const resolver: ProxyResolver = {
@@ -420,6 +470,62 @@ test("managed mode honors req.setTimeout during stalled node:https CONNECT hands
       proxy.stop();
     }
   });
+});
+
+test("node CONNECT agent detaches its parser before destination TLS", async () => {
+  const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
+  const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };
+  const originalNetConnect = netMutable.connect;
+  const originalTlsConnect = tlsMutable.connect;
+  let proxySocket: FakeProxySocket | undefined;
+  let tlsConnects = 0;
+  const resolver: ProxyResolver = {
+    active: true,
+    describeProxy: () => "http://proxy.example:8080/",
+    explain: () => {
+      throw new Error("not used");
+    },
+    getProxyForUrl: () => "http://proxy.example:8080/",
+  };
+  const agent = createNodeProxyAgent(resolver, undefined, "https");
+  try {
+    netMutable.connect = () => {
+      proxySocket = new FakeProxySocket();
+      queueMicrotask(() => proxySocket?.emit("connect"));
+      return proxySocket as unknown as net.Socket;
+    };
+    tlsMutable.connect = (...args: unknown[]) => {
+      tlsConnects += 1;
+      const callback = args.find((arg): arg is () => void => typeof arg === "function");
+      const socket = new FakeProxySocket() as unknown as tls.TLSSocket;
+      queueMicrotask(() => {
+        socket.emit("secureConnect");
+        callback?.();
+      });
+      return socket;
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      const req = https.get("https://example.test/", { agent, timeout: 1_000 }, () => {});
+      req.on("error", reject);
+      req.on("socket", () => {
+        proxySocket?.emit("data", Buffer.from("encrypted target bytes"));
+        setImmediate(() => {
+          try {
+            assert.equal(tlsConnects, 1);
+            req.destroy();
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        });
+      });
+    });
+  } finally {
+    netMutable.connect = originalNetConnect;
+    tlsMutable.connect = originalTlsConnect;
+    agent.destroy();
+  }
 });
 
 test("ambient Node proxy helper trusts HTTPS proxy endpoints with scoped proxy TLS", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import test from "node:test";
 import {
+  createAmbientNodeProxyAgent,
+  hasAmbientNodeProxyConfigured,
   installGlobalProxy,
   installProxyline,
   openProxyConnectTunnel,
@@ -184,6 +186,77 @@ test("ambient mode falls back to ALL_PROXY when protocol proxy scheme is unsuppo
     assert.equal(decision.proxyUrl, "http://fallback.example:8080/");
   } finally {
     proxy.stop();
+  }
+});
+
+test("ambient Node proxy helper only creates an agent when env proxy applies", () => {
+  const inactiveAgent = withProxyEnv({}, () => createAmbientNodeProxyAgent());
+  assert.equal(inactiveAgent, undefined);
+
+  const httpOnlyHttps = withProxyEnv({ HTTP_PROXY: "http://proxy.example:8080" }, () =>
+    createAmbientNodeProxyAgent({ protocol: "https" }),
+  );
+  assert.equal(httpOnlyHttps, undefined);
+
+  const httpsAgent = withProxyEnv({ HTTPS_PROXY: "http://proxy.example:8080" }, () =>
+    createAmbientNodeProxyAgent({ protocol: "https" }),
+  );
+  try {
+    assert.ok(httpsAgent);
+  } finally {
+    httpsAgent?.destroy();
+  }
+
+  const allProxyAgent = withProxyEnv({ ALL_PROXY: "http://proxy.example:8080" }, () =>
+    createAmbientNodeProxyAgent({ protocol: "https" }),
+  );
+  try {
+    assert.ok(allProxyAgent);
+  } finally {
+    allProxyAgent?.destroy();
+  }
+});
+
+test("ambient Node proxy configured helper honors protocol and no-proxy", () => {
+  const hasHttp = withProxyEnv({ HTTP_PROXY: "http://proxy.example:8080" }, () =>
+    hasAmbientNodeProxyConfigured({ protocol: "http" }),
+  );
+  const hasHttps = withProxyEnv({ HTTP_PROXY: "http://proxy.example:8080" }, () =>
+    hasAmbientNodeProxyConfigured({ protocol: "https" }),
+  );
+  const bypassed = withProxyEnv(
+    { HTTPS_PROXY: "http://proxy.example:8080", NO_PROXY: "proxyline.invalid" },
+    () => hasAmbientNodeProxyConfigured({ protocol: "https" }),
+  );
+
+  assert.equal(hasHttp, true);
+  assert.equal(hasHttps, false);
+  assert.equal(bypassed, false);
+});
+
+test("ambient Node proxy helper uses the provided env snapshot for routing", () => {
+  const agent = withProxyEnv({}, () =>
+    createAmbientNodeProxyAgent({
+      env: {
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: "http://snapshot.example:8080",
+        ALL_PROXY: undefined,
+        NO_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+        all_proxy: undefined,
+        no_proxy: undefined,
+      },
+    }),
+  );
+  try {
+    assert.ok(agent);
+    assert.equal(
+      agent.getProxyForUrl("https://api.example.com/", undefined as never),
+      "http://snapshot.example:8080/",
+    );
+  } finally {
+    agent?.destroy();
   }
 });
 


### PR DESCRIPTION
## Summary

- add ambient Node proxy helper exports for conditional agent creation
- replace the `proxy-agent` dependency with Proxyline's scoped HTTP/HTTPS Node agent
- document the helper and add regression/e2e coverage for env snapshots and CONNECT target parsing

## Validation

- `git diff --check`
- `pnpm test`
