### PR TITLE
docs: record IPv6 proxy TLS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.4 - Unreleased
 
+- Fixed managed HTTPS proxy connections to IPv6 literal endpoints so equivalent compressed and expanded certificate addresses validate without sending IP-literal SNI.
 - Updated Undici to 8.5.0 and raised the compatible peer floor to pick up current security fixes; refreshed pnpm, Node types, and transitive esbuild tooling.
 
 ## 0.3.3 - 2026-05-18


### PR DESCRIPTION
## Summary

- record the user-visible IPv6 HTTPS proxy certificate-validation fix already landed in https://github.com/openclaw/proxyline/pull/8
- keep the unreleased 0.3.4 notes complete and ordered by user impact

## Proof

- `git diff --check`
- `npx --yes pnpm@11.9.0 package:dry-run`
- exact parent code commit: `npx --yes pnpm@11.9.0 check` (111/111), `npx --yes pnpm@11.9.0 test` (111/111), docs build, zero-advisory audit, no outdated dependencies
- structured Codex autoreview of the landed security-refresh commit: clean, no accepted/actionable findings

## Risk

Low. Changelog-only; one insertion, no runtime or package metadata changes.
