### PR TITLE
docs: codify vision and refresh workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Lint workflows
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
@@ -43,10 +43,10 @@ jobs:
           - windows-latest
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.9.0
           run_install: false

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -39,11 +39,11 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, proxyline, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.8
+      - uses: pnpm/action-setup@v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Lint workflows
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
@@ -27,10 +27,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.9.0
           run_install: false

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,10 +24,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.9.0
           run_install: false

--- a/.github/workflows/proxyline-npm-release.yml
+++ b/.github/workflows/proxyline-npm-release.yml
@@ -17,10 +17,10 @@ jobs:
     environment: npm-release
     steps:
       - name: Check out
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.9.0
           run_install: false

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,48 @@
+# Proxyline Vision
+
+Proxyline makes Node.js proxy routing explicit, observable, and difficult to bypass accidentally. It is a process runtime for applications that need one coherent egress policy across Node HTTP(S), global fetch/Undici, compatible WebSocket clients, and explicit CONNECT tunnels.
+
+## Product principles
+
+1. **Managed mode fails closed.** Missing or unsupported managed proxy configuration is an error. Covered traffic must not fall back to a direct connection because proxy setup failed.
+2. **Ambient mode is predictable compatibility.** It follows the conventional proxy environment captured at install time, including `NO_PROXY`, and remains inactive when no supported proxy is configured.
+3. **Bypasses are explicit and auditable.** Direct routing in managed mode requires a narrow `bypassPolicy`, `registerBypass()`, or `withBypass()` decision. Do not add hidden hostname, loopback, or error-based bypasses.
+4. **Security boundaries stay honest.** Documentation and diagnostics must distinguish covered surfaces from raw sockets, pre-captured functions, private/native transports, DNS, and other out-of-process behavior that Proxyline cannot enforce.
+5. **TLS identity and trust remain scoped.** Preserve destination TLS options and identity checks. Trust for a private proxy CA applies only to the proxy connection; never require process-wide verification disablement or global CA mutation.
+6. **Every routing decision is explainable without leaking credentials.** New surfaces and failure modes should integrate with structured decisions, lifecycle events, and proxy URL redaction.
+7. **Installation is reversible and singular.** Proxyline owns one process-wide runtime, rejects accidental competing installs, and restores every captured global it replaces.
+
+## Scope
+
+Proxyline owns proxy policy for Node-process transports it can patch safely or expose through explicit helpers. It should deepen correctness and coverage for those surfaces before expanding into unrelated networking infrastructure.
+
+Supported proxy endpoints remain HTTP and HTTPS. SOCKS, PAC evaluation, raw `net`/`tls` interception, operating-system enforcement, DNS policy, and arbitrary native transport rewriting are separate product decisions, not implicit compatibility work.
+
+New public APIs should provide a clear improvement in routing safety, observability, lifecycle control, or integration coverage. Avoid convenience wrappers that do not strengthen the core policy.
+
+## Compatibility
+
+- The documented public API, error codes, mode semantics, event shapes, and package exports are compatibility contracts.
+- Node and Undici support must match the declared engine and peer ranges and be exercised at the minimum supported versions.
+- Process-global behavior is intentional. New patches must define install order, singleton interaction, ownership, and exact cleanup behavior.
+- Prefer removing obsolete internal paths over carrying aliases or fallbacks without a documented tagged upgrade need.
+- Keep runtime dependencies small. Shared transport state, especially Undici's global dispatcher, must come from the host-compatible dependency rather than a hidden second runtime.
+
+## Verification policy
+
+Routing changes require proof through the real in-process proxy lab at the changed boundary: HTTP or CONNECT shape, TLS identity, authentication, denial, bypass, cleanup, and observability as applicable. Mocks and type checks supplement that proof but do not replace it.
+
+Before landing runtime changes:
+
+- add focused regression coverage;
+- run the coverage-gated check and full package tests;
+- verify built package and docs artifacts;
+- test the declared Node matrix in CI;
+- audit dependency and workflow-action freshness;
+- record exact-head proof and any boundary that could not be exercised.
+
+External-provider or platform-specific integrations require a real live path when one exists. If that proof is unavailable, keep the limitation explicit rather than weakening the managed-mode guarantee.
+
+## Release policy
+
+User-visible behavior changes belong in the unreleased changelog. Patch releases cover compatible fixes, security maintenance, and tooling updates; additive public API work normally requires a minor release; breaking contracts require explicit major-version approval. A GitHub Release is the npm publication trigger, and its notes must carry the complete changelog plus exact CI, package, registry, tarball, and integrity proof.


### PR DESCRIPTION
## Summary

- add a durable `VISION.md` for fail-closed managed routing, explicit/auditable bypasses, honest security boundaries, scoped TLS trust, compatibility, verification, and release policy
- update `actions/checkout` from 6.0.2 to 7.0.0 across CI, package, pages, release, and Crabbox hydration workflows
- update `pnpm/action-setup` from 6.0.5/6.0.8 to 6.0.9 across the same workflows

## Dependency and security audit

- `pnpm audit --json`: zero advisories
- `pnpm outdated --format json`: no eligible package updates
- `@types/node 26.1.0` was published after the predecessor refresh but is inside the repository's minimum-release-age window; it is intentionally deferred without adding an exception
- `actions/setup-node 6.4.0` and `rhysd/actionlint 1.7.12` remain current
- checkout v7 adds safer fork pull-request handling and refreshed dependencies; action-setup 6.0.9 includes state/self-update/Windows fixes

## Proof

- `pnpm install --frozen-lockfile`
- `pnpm check`: 111/111 coverage tests plus package artifact test
- `pnpm test`: 111/111 full tests plus package artifact test
- `pnpm docs:build`
- `pnpm package:dry-run`
- `actionlint`
- structured Codex autoreview: clean; zero accepted/actionable findings
- public model identifier audit: PASS; no model-bearing code, fixtures, metadata, or proof text

## Risk

Low. Runtime/package output is unchanged. Workflow actions move to signed stable releases and exact SHAs in normal workflows; the generated Crabbox hydration workflow advances its version tags. Hosted exact-head CI remains the final execution proof.
