### PR TITLE
fix(connect): tunnels hang after caller cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.4 - Unreleased
 
+- Added `AbortSignal` cancellation to explicit CONNECT tunnels, including active socket cleanup.
 - Fixed managed HTTPS proxy connections to IPv6 literal endpoints so equivalent compressed and expanded certificate addresses validate without sending IP-literal SNI.
 - Updated Undici to 8.5.0 and raised the compatible peer floor to pick up current security fixes; refreshed pnpm, Node types, and transitive esbuild tooling.
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ const socket = new WebSocket("wss://events.example.com/", {
 ```ts
 import { openProxyConnectTunnel } from "@openclaw/proxyline";
 
+const controller = new AbortController();
 const socket = await openProxyConnectTunnel({
   proxyUrl: "https://proxy.corp.example:8443",
   proxyTls: { caFile: "/etc/proxy-ca.pem" },
   targetHost: "api.example.com",
   targetPort: 443,
   timeoutMs: 2_000,
+  signal: controller.signal,
 });
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -257,6 +257,7 @@ type OpenProxyConnectTunnelOptions = Readonly<{
   targetHost: string;
   targetPort: number;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }>;
 ```
 
@@ -264,6 +265,7 @@ type OpenProxyConnectTunnelOptions = Readonly<{
 - `proxyTls` — CA trust for HTTPS proxies. See [Proxy TLS](./proxy-tls.md).
 - `targetHost` / `targetPort` — what to ask the proxy to connect to.
 - `timeoutMs` — overall budget for the CONNECT handshake.
+- `signal` — optional caller cancellation; aborting rejects the handshake and destroys its active proxy socket.
 
 ### `AmbientNodeProxyAgentOptions`
 

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -83,6 +83,7 @@ const socket = await openProxyConnectTunnel({
   targetHost: "api.example.com",
   targetPort: 443,
   timeoutMs: 2_000,
+  signal: AbortSignal.timeout(2_000),
 });
 ```
 
@@ -93,6 +94,7 @@ Properties:
 - Userinfo in the `proxyUrl` becomes a `Proxy-Authorization: Basic ...` header.
 - A bounded `16 KiB` header buffer protects against malicious or runaway proxy responses.
 - `timeoutMs` is enforced and emits a `CONNECT_FAILED` error on expiry.
+- `signal` aborts an in-progress handshake and destroys its active proxy socket.
 - Bytes the proxy sends after the response headers are re-injected with `socket.unshift()` so the caller sees the full target stream.
 - Non-2xx status lines, header overrun, premature close, and socket errors are all surfaced as `ProxylineError` with code `CONNECT_FAILED`.
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -8,6 +8,7 @@ export type OpenProxyConnectTunnelOptions = Readonly<{
   targetHost: string;
   targetPort: number;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }>;
 
 const MAX_CONNECT_RESPONSE_HEADER_BYTES = 16 * 1024;
@@ -131,6 +132,7 @@ export async function openProxyConnectTunnel(
       socket?.off("close", onClosed);
       socket?.off("connect", onConnected);
       socket?.off("secureConnect", onConnected);
+      options.signal?.removeEventListener("abort", onAbort);
     };
 
     const fail = (error: unknown): void => {
@@ -203,7 +205,16 @@ export async function openProxyConnectTunnel(
       fail(new Error("proxy socket closed before CONNECT response"));
     };
 
+    const onAbort = (): void => {
+      fail(options.signal?.reason ?? new Error("proxy CONNECT aborted"));
+    };
+
     try {
+      options.signal?.addEventListener("abort", onAbort, { once: true });
+      if (options.signal?.aborted) {
+        onAbort();
+        return;
+      }
       if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
         timeout = setTimeout(() => {
           fail(new Error(`proxy CONNECT timed out after ${Math.trunc(options.timeoutMs ?? 0)}ms`));

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1898,6 +1898,50 @@ test("CONNECT helper times out stalled proxy responses", async () => {
   });
 });
 
+test("CONNECT helper rejects an already-aborted signal without starting CONNECT", async () => {
+  await withStalledConnectProxy(async (proxyUrl, activeSockets) => {
+    const controller = new AbortController();
+    controller.abort(new Error("connect cancelled"));
+
+    await assert.rejects(
+      openProxyConnectTunnel({
+        proxyUrl,
+        targetHost: "api.example.com",
+        targetPort: 443,
+        timeoutMs: 1_000,
+        signal: controller.signal,
+      }),
+      /connect cancelled/,
+    );
+    assert.equal(activeSockets.size, 0);
+  });
+});
+
+test("CONNECT helper aborts a stalled handshake and destroys its socket", async () => {
+  await withStalledConnectProxy(async (proxyUrl, activeSockets) => {
+    const controller = new AbortController();
+    const connecting = openProxyConnectTunnel({
+      proxyUrl,
+      targetHost: "api.example.com",
+      targetPort: 443,
+      timeoutMs: 10_000,
+      signal: controller.signal,
+    });
+    for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(activeSockets.size, 1);
+
+    controller.abort(new Error("connect cancelled"));
+
+    await assert.rejects(connecting, /connect cancelled/);
+    for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(activeSockets.size, 0);
+  });
+});
+
 test("CONNECT helper rejects proxy close before response", async () => {
   const proxy = http.createServer();
   proxy.on("connect", (_req, socket) => {
@@ -1932,13 +1976,16 @@ test("CONNECT helper rejects proxy close before response", async () => {
 test("CONNECT helper opens an explicit tunnel through the lab proxy", async () => {
   const lab = await startProxyLab();
   const target = new URL(lab.targetUrl);
+  const controller = new AbortController();
   const socket = await openProxyConnectTunnel({
     proxyUrl: lab.proxyUrl,
     targetHost: target.hostname,
     targetPort: Number(target.port),
     timeoutMs: 1_000,
+    signal: controller.signal,
   });
   try {
+    controller.abort(new Error("handshake already completed"));
     const response = await new Promise<string>((resolve, reject) => {
       let body = "";
       socket.setEncoding("utf8");


### PR DESCRIPTION
## What Problem This Solves

Callers of `openProxyConnectTunnel()` cannot currently cancel a CONNECT handshake while the proxy connection or response is stalled. That leaves the proxy socket alive until the timeout expires and forces consumers such as OpenClaw APNs to choose between delayed cancellation and maintaining a duplicate CONNECT implementation.

This is the upstream prerequisite for removing the local proxy tunnel stack from openclaw/openclaw#109647.

## Why This Change Was Made

This extends Proxyline's existing CONNECT owner with an optional `signal?: AbortSignal` instead of moving proxy connection, authentication, TLS, timeout, or socket-lifecycle policy into callers.

- An already-aborted signal rejects before a proxy socket is opened.
- Aborting during the handshake rejects through the existing CONNECT error contract and destroys the active socket.
- The listener is removed when the handshake settles, so aborting after success does not affect the socket returned to the caller.

## User Impact

Applications can promptly cancel stalled proxy tunnel setup without waiting for the configured timeout and without implementing a second CONNECT stack.

## Evidence

- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy pnpm check`
  - 113 tests passed.
  - Coverage and package artifact checks passed.
- `pnpm docs:build`
- Added coverage for pre-aborted cancellation, cancellation during a stalled handshake with socket cleanup, and abort after successful socket ownership transfer.
- Full architecture/correctness review passed for commit `a487e8983b0faf6889e9d20211afcaf15c9eb090` with no findings.

### Live stalled-CONNECT proof

Run on commit `a487e8983b0faf6889e9d20211afcaf15c9eb090` with Node.js `v24.16.0` and pnpm `11.9.0` at `2026-07-20T17:34:02Z`.

The standalone harness opened a real loopback HTTP proxy, accepted a CONNECT request without sending a response, counted the server-side socket, aborted the caller, and waited for the socket's `end` or `close` event. The CONNECT timeout was 10 seconds, so the 1 ms rejection below came from the abort path rather than timeout expiry.

```text
stalled_connect_active_sockets_before_abort=1
abort_rejected=true elapsed_ms=1 error_code=CONNECT_FAILED
abort_error="Proxy CONNECT failed via http://127.0.0.1:36115/: live-proof cancellation"
active_sockets_after_abort=0
```

This demonstrates that a stalled live CONNECT had one active socket before cancellation, rejected promptly with the existing error contract, and released the active socket immediately after cancellation.
