### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint workflows
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
@@ -43,16 +43,16 @@ jobs:
           - windows-latest
     steps:
       - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.9.0
+          version: 11.18.0
           run_install: false
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.9.0"
+  PNPM_VERSION: "11.18.0"
 
 jobs:
   hydrate:
@@ -39,15 +39,15 @@ jobs:
     runs-on: [self-hosted, crabbox, openclaw, proxyline, "${{ inputs.crabbox_runner_label }}"]
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint workflows
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
@@ -27,16 +27,16 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.9.0
+          version: 11.18.0
           run_install: false
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.19.0
           cache: pnpm

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,16 +24,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.9.0
+          version: 11.18.0
           run_install: false
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -46,13 +46,13 @@ jobs:
         run: pnpm docs:build
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist/docs-site
 
       - name: Deploy Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/proxyline-npm-release.yml
+++ b/.github/workflows/proxyline-npm-release.yml
@@ -17,16 +17,16 @@ jobs:
     environment: npm-release
     steps:
       - name: Check out
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11.9.0
+          version: 11.18.0
           run_install: false
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.19.0
           cache: pnpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.5 - Unreleased
 
+- Updated Undici, WebSocket and TypeScript tooling, pnpm, and pinned GitHub Actions to their latest stable releases.
+
 ## 0.3.4 - 2026-07-20
 
 - Added `AbortSignal` cancellation to explicit CONNECT tunnels, including active socket cleanup.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/openclaw/proxyline/issues"
   },
   "homepage": "https://proxyline.dev",
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.18.0",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -62,12 +62,12 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "devDependencies": {
-    "@types/node": "26.1.1",
+    "@types/node": "26.1.2",
     "@types/ws": "8.18.1",
-    "tsx": "4.23.0",
+    "tsx": "4.23.1",
     "typescript": "^7.0.2",
-    "undici": "8.6.0",
-    "ws": "8.21.0"
+    "undici": "8.9.0",
+    "ws": "8.21.1"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,23 @@ importers:
   .:
     devDependencies:
       '@types/node':
-        specifier: 26.1.1
-        version: 26.1.1
+        specifier: 26.1.2
+        version: 26.1.2
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
       tsx:
-        specifier: 4.23.0
-        version: 4.23.0
+        specifier: 4.23.1
+        version: 4.23.1
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       undici:
-        specifier: 8.6.0
-        version: 8.6.0
+        specifier: 8.9.0
+        version: 8.9.0
       ws:
-        specifier: 8.21.0
-        version: 8.21.0
+        specifier: 8.21.1
+        version: 8.21.1
 
 packages:
 
@@ -185,8 +185,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -321,8 +321,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  tsx@4.23.0:
-    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -334,12 +334,12 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.6.0:
-    resolution: {integrity: sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==}
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -430,13 +430,13 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@types/node@26.1.1':
+  '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -530,7 +530,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  tsx@4.23.0:
+  tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -561,6 +561,6 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.6.0: {}
+  undici@8.9.0: {}
 
-  ws@8.21.0: {}
+  ws@8.21.1: {}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -524,12 +524,27 @@ function createUndiciProxyAgent(
           ...(net.isIP(proxyHostname) === 6 ? { checkServerIdentity: checkProxyServerIdentity } : {}),
         }
       : undefined;
+  const dispatcherFactory = createProxyClientFactory();
   return new UndiciProxyAgent({
     ...resolveUndiciBaseOptions(options.undici),
     uri: proxyUrl,
-    clientFactory: createProxyClientFactory(),
+    clientFactory: dispatcherFactory,
+    factory: dispatcherFactory,
     ...(proxyTls !== undefined ? { proxyTls } : {}),
   } as ConstructorParameters<typeof UndiciProxyAgent>[0]);
+}
+
+function normalizeUndiciDispatchOptions(
+  options: Dispatcher.DispatchOptions,
+): Dispatcher.DispatchOptions {
+  if (options.origin === undefined || !/^https?:\/\//i.test(options.path)) {
+    return options;
+  }
+  const pathUrl = new URL(options.path);
+  return {
+    ...options,
+    path: `${pathUrl.pathname}${pathUrl.search}`,
+  };
 }
 
 function createUndiciProxyDispatcher(
@@ -585,10 +600,11 @@ class ManagedUndiciDispatcher extends Dispatcher {
     if (this.#closedError !== undefined) {
       return reportClosedDispatchError(handler, this.#closedError);
     }
-    const url = resolveUndiciDispatchUrl(options);
+    const normalizedOptions = normalizeUndiciDispatchOptions(options);
+    const url = resolveUndiciDispatchUrl(normalizedOptions);
     const proxyUrl = url === undefined ? "" : this.#resolver.getProxyForUrl(url, "undici");
     const dispatcher = proxyUrl === "" ? this.#directDispatcher : this.#proxyDispatcher(proxyUrl);
-    return dispatcher.dispatch(options, handler);
+    return dispatcher.dispatch(normalizedOptions, handler);
   }
 
   public override close(callback: () => void): void;
@@ -671,10 +687,11 @@ class AmbientUndiciDispatcher extends Dispatcher {
     if (this.#closedError !== undefined) {
       return reportClosedDispatchError(handler, this.#closedError);
     }
-    const url = resolveUndiciDispatchUrl(options);
+    const normalizedOptions = normalizeUndiciDispatchOptions(options);
+    const url = resolveUndiciDispatchUrl(normalizedOptions);
     const proxyUrl = url === undefined ? undefined : resolveAmbientProxyForUrl(url, this.#env);
     const dispatcher = proxyUrl === undefined ? this.#directDispatcher : this.#proxyDispatcher(proxyUrl);
-    return dispatcher.dispatch(options, handler);
+    return dispatcher.dispatch(normalizedOptions, handler);
   }
 
   public override close(callback: () => void): void;


### PR DESCRIPTION
## Summary

- update all stale npm dependencies and the pnpm package-manager pin
- pin the repository's GitHub Actions to their current immutable SHAs, including the available major updates
- adapt the managed and ambient Undici dispatchers to Undici 8.9's forward-proxy factory path
- normalize absolute-form request paths before policy checks and target dispatch

Undici 8.9 exposed two compatibility regressions during the update: forward-proxy connections bypassed Proxyline's IP-literal SNI sanitizer, and an absolute-form low-level request could be concatenated into a malformed target. Reusing the same proxy client factory for both Undici factory paths and normalizing the path at Proxyline's dispatcher boundary fixes both without changing the public API.

## Exact-head live behavior proof

Tested commit: `7c506c41cafa0724339608d7bd8c89edeb68e567`

After building the package, a standalone script loaded the public API from `dist/index.js` and drove it against live loopback HTTP and HTTPS proxy servers. The absolute-form request reached the intended socket-origin target and was denied by the proxy policy with 403; it was not concatenated into a malformed URL. Both IP-literal HTTPS proxy connections completed with no SNI event.

```json
{
  "absoluteForm": {
    "response": { "statusCode": 403, "body": "blocked by proxy lab" },
    "proxyEvents": [
      { "type": "request", "method": "GET", "url": "http://127.0.0.1:<port>/denied" },
      { "type": "deny", "status": 403, "url": "http://127.0.0.1:<port>/denied" }
    ]
  },
  "ipv4": { "proxyHost": "127.0.0.1", "statusCode": 403, "sniEvents": [] },
  "ipv6": { "proxyHost": "::1", "statusCode": 403, "sniEvents": [] }
}
```

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check` — 113/113 tests passed, including package-artifact verification
- `pnpm test` — 113/113 tests passed
- standalone built-artifact integration run passed for absolute-form routing and IPv4/IPv6 IP-literal SNI suppression, with inspectable output above
- `pnpm docs:build`; served the generated site locally and fetched it successfully (HTTP 200, 28,134 bytes)
- `pnpm package:dry-run` — built the expected `@openclaw/proxyline@0.3.4` package contents
- `pnpm audit --audit-level high --json` — zero vulnerabilities at every severity
- `pnpm outdated --format json` — no stale packages
- `actionlint` and `git diff --check` — clean
- independent branch review — no P0/P1 findings (0.91 confidence)

No release is included.
