### PR TITLE
fix(http): deliver forward createConnection sockets only via callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.6 - Unreleased
 
+- Fixed HTTP forwarding through HTTPS proxies to wait for the proxy TLS handshake before assigning the socket to Node's agent. Thanks @SebTardif.
+
 ## 0.3.5 - 2026-08-01
 
 - Fixed malformed percent-encoding in proxy credentials to fail through CONNECT promises and Node request errors with `INVALID_PROXY_USERINFO`. Thanks @SebTardif.

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -442,6 +442,9 @@ class ProxylineHttpForwardAgent extends http.Agent {
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
     const socket = connectToProxy(this.#proxy, this.#proxyTls);
+    // When Node supplies an async callback, deliver the socket only through that
+    // path. Returning the same socket as well double-invokes Agent setup and can
+    // hand an unready TLS proxy socket to plain HTTP forward traffic.
     if (callback !== undefined) {
       const onError = (error: Error): void => {
         callback(error, socket);
@@ -452,6 +455,7 @@ class ProxylineHttpForwardAgent extends http.Agent {
       };
       socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
       socket.once("error", onError);
+      return undefined as unknown as net.Socket;
     }
     return socket;
   }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1626,6 +1626,40 @@ test("managed mode trusts an HTTPS proxy endpoint with scoped CA", async () => {
   }
 });
 
+test("managed node:http waits for the HTTPS proxy handshake before assigning its socket", async () => {
+  const lab = await startProxyLab({ secureProxy: true });
+  const proxyCa = lab.proxyCa;
+  assert.ok(proxyCa);
+  const proxy = installGlobalProxy({
+    mode: "managed",
+    proxyUrl: lab.proxyUrl,
+    proxyTls: { ca: proxyCa },
+  });
+  try {
+    let socketState: { authorized: boolean; connecting: boolean } | undefined;
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get(`${lab.targetUrl}/allowed`, (res) => {
+        res.resume();
+        res.once("end", resolve);
+      });
+      req.once("socket", (socket) => {
+        const proxySocket = socket as tls.TLSSocket;
+        socketState = {
+          authorized: proxySocket.authorized,
+          connecting: proxySocket.connecting,
+        };
+      });
+      req.once("error", reject);
+    });
+
+    assert.deepEqual(socketState, { authorized: true, connecting: false });
+    assert.ok(lab.events.some((event) => event.type === "allow"));
+  } finally {
+    proxy.stop();
+    await lab.close();
+  }
+});
+
 test("managed mode does not send IP-literal SNI to HTTPS proxy endpoints", async () => {
   const lab = await startProxyLab({ secureProxy: true, proxyHost: "127.0.0.1" });
   const proxyCa = lab.proxyCa;


### PR DESCRIPTION
## What Problem This Solves

`ProxylineHttpForwardAgent.createConnection` both returned the proxy socket and invoked the async callback when Node provided one. That double-delivers the socket into Agent setup and can hand an unready TLS proxy socket to plain HTTP forward traffic. The CONNECT agent already requires callback-only delivery.

## Evidence

### After

When `callback` is provided, register connect/error handlers and `return undefined as unknown as net.Socket` (callback-only). Sync path still returns the socket when no callback is given.

```console
$ pnpm test
ℹ tests 117
ℹ pass 117
```

## Real behavior proof

- **Behavior or issue addressed:** Avoid double socket delivery in HTTP forward `createConnection`.
- **Real environment tested:** macOS arm64, Node, `/tmp/oc-batch-20260802/proxyline`.
- **Exact steps or command run after this patch:** `pnpm test` (117 pass).
- **Evidence after fix:** Full package suite green after callback-only change.
- **Observed result after fix:** Existing CONNECT and ambient proxy tests still pass.
- **What was not tested:** Custom harness asserting Node Agent `createConnection` call counts against a live TLS proxy.

## Summary

Callback-only delivery for `ProxylineHttpForwardAgent.createConnection` when Node supplies a callback.
