### PR TITLE
chore: remove duplicate Crabbox version check

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -60,7 +60,6 @@ jobs:
           pnpm install --frozen-lockfile
           node --version
           pnpm --version
-          pnpm --version
 
       - name: Mark Crabbox ready
         shell: bash


### PR DESCRIPTION
## Summary

- Remove the second of two consecutive `pnpm --version` calls from the Crabbox hydration workflow.
- Keep all unusual tracked files that proved deliberate or referenced during the repository inventory.
- Leave `.gitignore` unchanged because no committed debris bypassed the existing rules.

## Hygiene evidence

- `.github/workflows/crabbox-hydrate.yml`: commit `b32cd0d` (`chore: add constrained Crabbox setup`, Vincent Koc, 2026-05-23) introduced two identical adjacent `pnpm --version` commands. The second call has no control-flow or diagnostic value beyond the first, so it is high-confidence duplicated workflow debris.

The inventory found no committed logs, scratch harnesses, tarballs, editor/OS junk, `node_modules`, `dist`, `coverage`, or other ignored output.

## Verification

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `CI=true pnpm check` (117 tests; coverage gate passed)
- `CI=true pnpm test`
- `CI=true pnpm docs:build`
- `CI=true pnpm package:dry-run`
- `autoreview --mode local --stream-engine-output` (clean; no findings)
