### PR TITLE
build: refresh dependencies and release tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.18.0
+          version: 11.20.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.18.0"
+  PNPM_VERSION: "11.20.0"
 
 jobs:
   hydrate:
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,9 +30,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.18.0
+          version: 11.20.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.18.0
+          version: 11.20.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/proxyline-npm-release.yml
+++ b/.github/workflows/proxyline-npm-release.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.18.0
+          version: 11.20.0
           run_install: false
 
       - name: Set up Node
@@ -34,7 +34,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Set up npm trusted publishing
-        run: npm install --global npm@11.19.0
+        run: npm install --global npm@12.0.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.3.7 - Unreleased
 
+- Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.
+- Updated Undici and tsx, pnpm and npm release tooling, and pinned GitHub Actions to their latest stable releases.
+
 ## 0.3.6 - 2026-08-02
 
 - Fixed HTTP forwarding through HTTPS proxies to wait for the proxy TLS handshake before assigning the socket to Node's agent. Thanks @SebTardif.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/openclaw/proxyline/issues"
   },
   "homepage": "https://proxyline.dev",
-  "packageManager": "pnpm@11.18.0",
+  "packageManager": "pnpm@11.20.0",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -64,9 +64,9 @@
   "devDependencies": {
     "@types/node": "26.1.2",
     "@types/ws": "8.18.1",
-    "tsx": "4.23.1",
+    "tsx": "4.23.5",
     "typescript": "^7.0.2",
-    "undici": "8.9.0",
+    "undici": "8.10.0",
     "ws": "8.21.1"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 8.18.1
         version: 8.18.1
       tsx:
-        specifier: 4.23.1
-        version: 4.23.1
+        specifier: 4.23.5
+        version: 4.23.5
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       undici:
-        specifier: 8.9.0
-        version: 8.9.0
+        specifier: 8.10.0
+        version: 8.10.0
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -321,8 +321,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  tsx@4.23.1:
-    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+  tsx@4.23.5:
+    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -334,8 +334,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.9.0:
-    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   ws@8.21.1:
@@ -530,7 +530,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  tsx@4.23.1:
+  tsx@4.23.5:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -561,6 +561,6 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.9.0: {}
+  undici@8.10.0: {}
 
   ws@8.21.1: {}


### PR DESCRIPTION
## Summary

- update Undici 8.9.0 → 8.10.0 and tsx 4.23.1 → 4.23.5
- update pnpm 11.18.0 → 11.20.0 across package metadata and workflows
- update npm release tooling 11.19.0 → 12.0.2 and `pnpm/action-setup` 6.0.9 → 6.0.10
- reconcile the 0.3.7 changelog with the landed CONNECT-timeout fix

`tsx` 4.23.8 is newer but was published today; the repository's two-day `minimumReleaseAge` supply-chain policy rejects it. Version 4.23.5 is the newest admissible release.

## Proof

- `pnpm check` — 120/120 pass with coverage gates
- `pnpm test` — 120/120 plus package artifact test pass
- `pnpm docs:build`
- `pnpm package:dry-run`
- `actionlint`
- `npx --yes npm@12.0.2 pack --dry-run` — builds the complete 52-file package
- neutral-directory packed-artifact integration with Undici 8.10.0: managed global fetch returned 200/`proxy-ok`, and the live proxy observed `GET http://example.test/live-proof?dep=undici-8.10.0`
- Codex autoreview: no accepted/actionable findings
