### PR TITLE
chore(deps): refresh development tooling

### DIFF
--- a/.github/workflows/proxyline-npm-release.yml
+++ b/.github/workflows/proxyline-npm-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24.15.0
+          node-version: 24.19.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
           registry-url: https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -62,12 +62,12 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "devDependencies": {
-    "@types/node": "26.1.2",
+    "@types/node": "26.2.0",
     "@types/ws": "8.18.1",
-    "tsx": "4.23.5",
+    "tsx": "4.23.11",
     "typescript": "^7.0.2",
     "undici": "8.10.0",
-    "ws": "8.21.1"
+    "ws": "8.21.3"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     devDependencies:
       '@types/node':
-        specifier: 26.1.2
-        version: 26.1.2
+        specifier: 26.2.0
+        version: 26.2.0
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
       tsx:
-        specifier: 4.23.5
-        version: 4.23.5
+        specifier: 4.23.11
+        version: 4.23.11
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -24,8 +24,8 @@ importers:
         specifier: 8.10.0
         version: 8.10.0
       ws:
-        specifier: 8.21.1
-        version: 8.21.1
+        specifier: 8.21.3
+        version: 8.21.3
 
 packages:
 
@@ -185,8 +185,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@types/node@26.1.2':
-    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -321,8 +321,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  tsx@4.23.5:
-    resolution: {integrity: sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==}
+  tsx@4.23.11:
+    resolution: {integrity: sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -338,8 +338,8 @@ packages:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
-  ws@8.21.1:
-    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -430,13 +430,13 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@types/node@26.1.2':
+  '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -530,7 +530,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  tsx@4.23.5:
+  tsx@4.23.11:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
@@ -563,4 +563,4 @@ snapshots:
 
   undici@8.10.0: {}
 
-  ws@8.21.1: {}
+  ws@8.21.3: {}


### PR DESCRIPTION
## Summary

- refresh `@types/node` from 26.1.2 to 26.2.0
- refresh `tsx` from 4.23.5 to 4.23.11
- refresh `ws` from 8.21.1 to 8.21.3
- update the npm release job from Node 24.15.0 to 24.19.0

pnpm 11.21.0 is not included because it is still inside the workspace's 48-hour minimum-release-age window. All pinned GitHub Actions and npm 12.0.2 are already current.

## Proof

- `pnpm install --frozen-lockfile`
- `pnpm audit --json` (0 advisories)
- `pnpm check` (120 coverage-gated tests plus package-artifact test)
- `pnpm test` (121 tests)
- `pnpm docs:build`
- `pnpm package:dry-run`
- `actionlint`
- built-library live HTTP proxy integration (one request, one proxy hit, `managed-proxy-active`)
- autoreview clean with no accepted/actionable findings
