### PR TITLE
fix(http): destroy pending forward sockets and isolate install onEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.3.8 - Unreleased
 
+- Fixed Node HTTP-forward agents to destroy pending proxy sockets when the agent is destroyed. Thanks @SebTardif.
+- Fixed runtime install so a throwing `onEvent` observer cannot orphan patched globals; the returned handle remains stoppable and replaceable. Thanks @SebTardif.
+
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## 0.3.8 - Unreleased
 
-- Fixed Node HTTP-forward agents to destroy pending proxy sockets when the agent is destroyed. Thanks @SebTardif.
-- Fixed runtime install so a throwing `onEvent` observer cannot orphan patched globals; the returned handle remains stoppable and replaceable. Thanks @SebTardif.
-
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -420,6 +420,7 @@ function destinationTlsConnectOptions(
 class ProxylineHttpForwardAgent extends http.Agent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
+  readonly #pendingConnectSockets = new Set<net.Socket>();
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
@@ -446,11 +447,14 @@ class ProxylineHttpForwardAgent extends http.Agent {
     // path. Returning the same socket as well double-invokes Agent setup and can
     // hand an unready TLS proxy socket to plain HTTP forward traffic.
     if (callback !== undefined) {
+      this.#pendingConnectSockets.add(socket);
       const onError = (error: Error): void => {
+        this.#pendingConnectSockets.delete(socket);
         callback(error, socket);
       };
       const onConnected = (): void => {
         socket.off("error", onError);
+        this.#pendingConnectSockets.delete(socket);
         callback(null, socket);
       };
       socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
@@ -458,6 +462,14 @@ class ProxylineHttpForwardAgent extends http.Agent {
       return undefined as unknown as net.Socket;
     }
     return socket;
+  }
+
+  public override destroy(): void {
+    for (const socket of this.#pendingConnectSockets) {
+      socket.destroy();
+    }
+    this.#pendingConnectSockets.clear();
+    super.destroy();
   }
 }
 

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -448,17 +448,33 @@ class ProxylineHttpForwardAgent extends http.Agent {
     // hand an unready TLS proxy socket to plain HTTP forward traffic.
     if (callback !== undefined) {
       this.#pendingConnectSockets.add(socket);
-      const onError = (error: Error): void => {
+      let settled = false;
+      const cleanup = (): void => {
         this.#pendingConnectSockets.delete(socket);
+        socket.off(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
+        socket.off("error", onError);
+        socket.off("close", onClosed);
+      };
+      const finish = (error: Error | null): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
         callback(error, socket);
       };
+      const onError = (error: Error): void => {
+        finish(error);
+      };
+      const onClosed = (): void => {
+        finish(new ProxylineError("CONNECT_FAILED", "proxy socket closed before connection completed"));
+      };
       const onConnected = (): void => {
-        socket.off("error", onError);
-        this.#pendingConnectSockets.delete(socket);
-        callback(null, socket);
+        finish(null);
       };
       socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
       socket.once("error", onError);
+      socket.once("close", onClosed);
       return undefined as unknown as net.Socket;
     }
     return socket;
@@ -466,7 +482,7 @@ class ProxylineHttpForwardAgent extends http.Agent {
 
   public override destroy(): void {
     for (const socket of this.#pendingConnectSockets) {
-      socket.destroy();
+      socket.destroy(new ProxylineError("CONNECT_FAILED", "proxy connection failed because agent was destroyed"));
     }
     this.#pendingConnectSockets.clear();
     super.destroy();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -283,7 +283,11 @@ function normalizeProxyUrl(value: string | URL | undefined): URL | undefined {
 }
 
 function emit(onEvent: ProxylineOptions["onEvent"], event: ProxylineEvent): void {
-  onEvent?.(event);
+  try {
+    onEvent?.(event);
+  } catch {
+    // Observer failures must not fail install or leave patched globals unstoppable.
+  }
 }
 
 function isProxyableUrlProtocol(protocol: string): boolean {
@@ -942,12 +946,6 @@ export function installProxyline(options: ProxylineOptions): ProxylineHandle {
         },
       )
     : undefined;
-  emit(options.onEvent, {
-    type: "runtime.installed",
-    mode: options.mode,
-    active: hasActiveProxy,
-    ...(redactedProxyUrl ? { proxyUrl: redactedProxyUrl } : {}),
-  });
 
   const handle: ProxylineHandle = {
     mode: options.mode,
@@ -1012,6 +1010,12 @@ export function installProxyline(options: ProxylineOptions): ProxylineHandle {
   };
 
   activeHandle = hasActiveProxy ? handle : activeHandle;
+  emit(options.onEvent, {
+    type: "runtime.installed",
+    mode: options.mode,
+    active: hasActiveProxy,
+    ...(redactedProxyUrl ? { proxyUrl: redactedProxyUrl } : {}),
+  });
   return handle;
 }
 

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -196,6 +196,36 @@ async function withStalledConnectProxy<T>(
   }
 }
 
+async function withStalledTlsProxy<T>(
+  run: (proxyUrl: string, activeSockets: Set<net.Socket>) => Promise<T>,
+): Promise<T> {
+  const activeSockets = new Set<net.Socket>();
+  const proxyServer = net.createServer((socket) => {
+    activeSockets.add(socket);
+    socket.once("close", () => activeSockets.delete(socket));
+    socket.resume();
+  });
+  proxyServer.listen(0, "127.0.0.1");
+  await once(proxyServer, "listening");
+  const address = proxyServer.address() as AddressInfo;
+  try {
+    return await run(`https://127.0.0.1:${address.port}`, activeSockets);
+  } finally {
+    for (const socket of activeSockets) {
+      socket.destroy();
+    }
+    await new Promise<void>((resolve, reject) => {
+      proxyServer.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
 class FakeProxySocket extends Duplex {
   public override _read(): void {}
 
@@ -782,43 +812,42 @@ test("node CONNECT agent destroys pending proxy sockets when the agent is destro
 });
 
 test("node HTTP-forward agent destroys pending proxy sockets when the agent is destroyed", async () => {
-  const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
-  const originalNetConnect = netMutable.connect;
-  const pendingSockets: FakeProxySocket[] = [];
-  const resolver: ProxyResolver = {
-    active: true,
-    describeProxy: () => "http://proxy.example:8080/",
-    explain: () => {
-      throw new Error("not used");
-    },
-    getProxyForUrl: () => "http://proxy.example:8080/",
-  };
-  const agent = createNodeProxyAgent(resolver, undefined, "http");
-  try {
-    netMutable.connect = () => {
-      const proxySocket = new FakeProxySocket();
-      pendingSockets.push(proxySocket);
-      return proxySocket as unknown as net.Socket;
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
     };
-
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
     const req = http.get("http://example.test/allowed", { agent }, () => {});
+    const requestError = once(req, "error").then(([error]) => error as Error);
     try {
-      for (let attempt = 0; attempt < 20 && pendingSockets.length === 0; attempt += 1) {
+      for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
         await new Promise((resolve) => setTimeout(resolve, 25));
       }
-      assert.equal(pendingSockets.length, 1);
-      assert.equal(pendingSockets[0]?.destroyed, false);
+      assert.equal(activeSockets.size, 1);
 
       agent.destroy();
 
-      assert.equal(pendingSockets[0]?.destroyed, true);
+      const error = await Promise.race([
+        requestError,
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error("request remained pending after agent destroy")), 500);
+        }),
+      ]);
+      assert.match(error.message, /agent was destroyed/);
+      for (let attempt = 0; attempt < 80 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
     } finally {
       req.destroy();
+      agent.destroy();
     }
-  } finally {
-    netMutable.connect = originalNetConnect;
-    agent.destroy();
-  }
+  });
 });
 
 test("node CONNECT agent fails requests when destination TLS closes during handshake", async () => {

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -781,6 +781,46 @@ test("node CONNECT agent destroys pending proxy sockets when the agent is destro
   });
 });
 
+test("node HTTP-forward agent destroys pending proxy sockets when the agent is destroyed", async () => {
+  const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
+  const originalNetConnect = netMutable.connect;
+  const pendingSockets: FakeProxySocket[] = [];
+  const resolver: ProxyResolver = {
+    active: true,
+    describeProxy: () => "http://proxy.example:8080/",
+    explain: () => {
+      throw new Error("not used");
+    },
+    getProxyForUrl: () => "http://proxy.example:8080/",
+  };
+  const agent = createNodeProxyAgent(resolver, undefined, "http");
+  try {
+    netMutable.connect = () => {
+      const proxySocket = new FakeProxySocket();
+      pendingSockets.push(proxySocket);
+      return proxySocket as unknown as net.Socket;
+    };
+
+    const req = http.get("http://example.test/allowed", { agent }, () => {});
+    try {
+      for (let attempt = 0; attempt < 20 && pendingSockets.length === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(pendingSockets.length, 1);
+      assert.equal(pendingSockets[0]?.destroyed, false);
+
+      agent.destroy();
+
+      assert.equal(pendingSockets[0]?.destroyed, true);
+    } finally {
+      req.destroy();
+    }
+  } finally {
+    netMutable.connect = originalNetConnect;
+    agent.destroy();
+  }
+});
+
 test("node CONNECT agent fails requests when destination TLS closes during handshake", async () => {
   const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
   const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -344,6 +344,34 @@ test("managed mode reuses compatible active runtime and replaces on request", ()
   }
 });
 
+test("throwing onEvent still yields a stoppable handle and allows replace", () => {
+  const handle = installGlobalProxy({
+    mode: "managed",
+    proxyUrl: "https://proxy.example:8443",
+    onEvent: (event) => {
+      if (event.type === "runtime.installed") {
+        throw new Error("observer failed");
+      }
+    },
+  });
+
+  try {
+    assert.equal(handle.active, true);
+    assert.equal(typeof handle.stop, "function");
+
+    const replacement = installGlobalProxy({
+      mode: "managed",
+      proxyUrl: "https://replacement.example:8443",
+      ifActive: "replace",
+    });
+    assert.notEqual(replacement, handle);
+    assert.equal(replacement.proxyUrl, "https://replacement.example:8443/");
+    replacement.stop();
+  } finally {
+    handle.stop();
+  }
+});
+
 test("ambient mode rejects compatible reuse when env snapshot changes", () => {
   withProxyEnv({ HTTP_PROXY: "http://old-proxy.example:8080" }, () => {
     const proxy = installGlobalProxy({ mode: "ambient" });


### PR DESCRIPTION
## What Problem This Solves

HTTP-forward Node agents waited for `connect` / `secureConnect` before handing the socket to Node's Agent (needed after the HTTPS-proxy handshake fix). Until that event, the Agent does not own the socket. `agent.destroy()` (request abort or `handle.stop()`) left those in-flight sockets open.

Separately, `installProxyline` emitted `runtime.installed` before assigning `activeHandle`. A throwing `onEvent` observer aborted install after globals were patched, so the caller never got a `stop()` handle and `ifActive: "replace"` could not recover.

## Evidence

```console
$ pnpm exec tsx --test test/index.test.ts test/e2e.test.ts
...
ℹ tests 111
ℹ pass 111
ℹ fail 0
ℹ duration_ms 1309
```

Red: forward-agent destroy test failed with `destroyed` still `false` before pending-socket tracking. Green after `destroy()` cleaned the set.

Red: throwing `onEvent` threw `observer failed` during install. Green: install returns a stoppable handle and `ifActive: "replace"` works.

## Real behavior proof
Behavior addressed: Destroy pending HTTP-forward proxy sockets on agent destroy, and keep install stoppable when `onEvent` throws.
Real environment tested: macOS, Node from the worktree, proxyline `/tmp/oc-impl-proxyline-sockets` head `8200e7fb`.
Exact steps or command run after this patch: `pnpm exec tsx --test test/index.test.ts test/e2e.test.ts`
Evidence after fix: terminal output copied below.

```console
$ pnpm exec tsx --test test/index.test.ts test/e2e.test.ts
ℹ tests 111
ℹ pass 111
ℹ fail 0
```

Observed result after fix: 111 tests pass, including the pending-socket destroy case (socket stays pending because `connect` is never emitted) and the throwing-onEvent install case.
What was not tested: A live HTTPS proxy whose TLS handshake stalls for minutes. The e2e uses a fake socket so the pending window is deterministic.
