### PR TITLE
fix(security): harden proxy and docs input handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.3.8 - Unreleased
+
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 0.3.8 - Unreleased
-
-- Hardened ambient `NO_PROXY` normalization, the local proxy test harness, TLS-isolation coverage, and generated documentation sanitization.
-
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.8 - Unreleased
 
+- Hardened ambient `NO_PROXY` normalization, the local proxy test harness, TLS-isolation coverage, and generated documentation sanitization.
+
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -422,16 +422,31 @@ function tocFromHtml(html) {
   const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
   let m;
   while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    let text = stripHtmlTags(m[3]).trim();
+    if (text.startsWith("#")) {
+      text = text.slice(1).trimStart();
+    }
     items.push({ level: Number(m[1]), id: m[2], text });
   }
   if (items.length < 2) return "";
   return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${items
     .map((i) => `<a class="toc-l${i.level}" href="#${i.id}">${escapeHtml(i.text)}</a>`)
     .join("")}</nav>`;
+}
+
+function stripHtmlTags(value) {
+  let text = "";
+  let insideTag = false;
+  for (const char of value) {
+    if (char === "<") {
+      insideTag = true;
+    } else if (char === ">") {
+      insideTag = false;
+    } else if (!insideTag) {
+      text += char;
+    }
+  }
+  return text;
 }
 
 function isHomePage(page) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -134,7 +134,12 @@ function matchesNoProxy(url: URL, env: ProxyEnvSnapshot): boolean {
 }
 
 function normalizeNoProxyHost(hostname: string): string {
-  const normalized = hostname.trim().toLowerCase().replace(/\.+$/, "");
+  const value = hostname.trim().toLowerCase();
+  let end = value.length;
+  while (end > 0 && value[end - 1] === ".") {
+    end -= 1;
+  }
+  const normalized = value.slice(0, end);
   return normalized.startsWith("[") && normalized.endsWith("]")
     ? normalized.slice(1, -1)
     : normalized;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1465,6 +1465,32 @@ test("managed mode routes node:http through the lab proxy and denies blocked pat
   }
 });
 
+test("proxy lab refuses HTTP and CONNECT requests outside its registered targets", async () => {
+  const lab = await startProxyLab();
+  const proxy = installGlobalProxy({ mode: "managed", proxyUrl: lab.proxyUrl });
+  try {
+    const denied = await readHttp("http://example.test/allowed");
+    await assert.rejects(readHttps("https://example.test/allowed"));
+
+    assert.equal(denied.status, 403);
+    assert.match(denied.body, /blocked by proxy lab/);
+    assert.ok(
+      lab.events.some(
+        (event) => event.type === "deny" && event.url === "http://example.test/allowed",
+      ),
+    );
+    assert.ok(
+      lab.events.some(
+        (event) =>
+          event.type === "deny_connect" && event.authority === "example.test:443",
+      ),
+    );
+  } finally {
+    proxy.stop();
+    await lab.close();
+  }
+});
+
 test("managed mode overrides a caller-provided direct node:http agent", async () => {
   const lab = await startProxyLab();
   const proxy = installGlobalProxy({ mode: "managed", proxyUrl: lab.proxyUrl });
@@ -1832,10 +1858,12 @@ test("managed mode does not send IPv6-literal SNI to HTTPS proxy endpoints", asy
   }
 });
 
-test("managed mode keeps destination TLS options from weakening HTTPS proxy TLS", async () => {
+test("managed mode does not reuse the destination CA for HTTPS proxy TLS", async () => {
   const lab = await startProxyLab({ secureProxy: true, secureTarget: true });
+  const targetCa = lab.targetCa;
+  assert.ok(targetCa);
   const proxy = installGlobalProxy({ mode: "managed", proxyUrl: lab.proxyUrl });
-  const callerAgent = new https.Agent({ rejectUnauthorized: false });
+  const callerAgent = new https.Agent({ ca: targetCa });
   try {
     await assert.rejects(
       readHttps(`${lab.targetUrl}/allowed`, { agent: callerAgent }),

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1465,13 +1465,23 @@ test("managed mode routes node:http through the lab proxy and denies blocked pat
   }
 });
 
-test("proxy lab refuses HTTP and CONNECT requests outside its registered targets", async () => {
+test("proxy lab allows registered HTTP authorities and refuses unregistered targets", async () => {
   const lab = await startProxyLab();
+  const targetUrl = new URL(lab.targetUrl);
+  const targetAliasUrl = `http://localhost:${targetUrl.port}/allowed`;
   const proxy = installGlobalProxy({ mode: "managed", proxyUrl: lab.proxyUrl });
   try {
+    const allowed = await readHttp(targetAliasUrl);
     const denied = await readHttp("http://example.test/allowed");
     await assert.rejects(readHttps("https://example.test/allowed"));
 
+    assert.equal(allowed.status, 200);
+    assert.equal(allowed.body, "allowed via target\n");
+    assert.ok(
+      lab.events.some(
+        (event) => event.type === "allow" && event.url === targetAliasUrl,
+      ),
+    );
     assert.equal(denied.status, 403);
     assert.match(denied.body, /blocked by proxy lab/);
     assert.ok(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -697,6 +697,24 @@ test("ambient mode suffix no-proxy entries also match the root host", () => {
   }
 });
 
+test("ambient mode handles dot-heavy nonmatching no-proxy entries", () => {
+  const proxy = withProxyEnv(
+    {
+      HTTP_PROXY: "http://proxy.example:8080",
+      NO_PROXY: `${".".repeat(4_096)}not-a-host`,
+    },
+    () => installProxyline({ mode: "ambient" }),
+  );
+  try {
+    const decision = proxy.explain("http://corp.example/");
+
+    assert.equal(decision.kind, "proxied");
+    assert.equal(decision.proxyUrl, "http://proxy.example:8080/");
+  } finally {
+    proxy.stop();
+  }
+});
+
 test("redactProxyUrl removes credentials, search, and hash", () => {
   assert.equal(
     redactProxyUrl("https://user:secret@proxy.example:8443/path?q=1#frag"),

--- a/test/scripts.test.ts
+++ b/test/scripts.test.ts
@@ -75,6 +75,44 @@ test("docs builder rejects duplicate output paths", () => {
   assert.match(result.stderr, /Duplicate docs output path "index\.html"/);
 });
 
+test("docs builder removes generated heading markup without reviving tags", () => {
+  const fixture = createDocsFixture();
+  fs.writeFileSync(
+    path.join(fixture, "docs", "README.md"),
+    [
+      "---",
+      "title: Home",
+      "permalink: /",
+      "---",
+      "",
+      "# Home",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(fixture, "docs", "getting-started.md"),
+    [
+      "# Getting Started",
+      "",
+      "## **First** heading",
+      "",
+      "## Literal `<scr<script>ipt>` heading",
+      "",
+    ].join("\n"),
+  );
+
+  const result = runDocsBuild(fixture);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const html = fs.readFileSync(
+    path.join(fixture, "dist", "docs-site", "getting-started.html"),
+    "utf8",
+  );
+  assert.match(html, /class="toc-l2"[^>]*>First heading<\/a>/);
+  assert.doesNotMatch(html, /class="toc-l2"[^>]*><strong>/);
+  assert.doesNotMatch(html, /<script>ipt/);
+});
+
 test("prepack build does not install or rewrite dependencies", () => {
   const script = fs.readFileSync(path.join(repoRoot, "scripts", "prepack-build.mjs"), "utf8");
 

--- a/test/support/proxy-lab.ts
+++ b/test/support/proxy-lab.ts
@@ -204,7 +204,7 @@ export async function startProxyLab(options: ProxyLabOptions = {}): Promise<Prox
       return;
     }
 
-    if (targetUrl.protocol !== "http:" || targetUrl.host !== targetAuthority) {
+    if (targetUrl.protocol !== "http:" || !allowLoopbackAuthorities.has(targetUrl.host)) {
       clientReq.resume();
       clientRes.writeHead(403, { "content-type": "text/plain" });
       clientRes.end("blocked by proxy lab\n");

--- a/test/support/proxy-lab.ts
+++ b/test/support/proxy-lab.ts
@@ -99,16 +99,6 @@ function closeServer(server: LabServer): Promise<void> {
   });
 }
 
-function isLoopbackHost(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase().replace(/\.+$/, "");
-  return (
-    normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
-    normalized === "[::1]" ||
-    normalized === "::1"
-  );
-}
-
 export async function startProxyLab(options: ProxyLabOptions = {}): Promise<ProxyLab> {
   const events: ProxyLabEvent[] = [];
   const denyPaths = new Set(["/denied"]);
@@ -214,22 +204,25 @@ export async function startProxyLab(options: ProxyLabOptions = {}): Promise<Prox
       return;
     }
 
-    if (isLoopbackHost(targetUrl.hostname) && !allowLoopbackAuthorities.has(targetUrl.host)) {
+    if (targetUrl.protocol !== "http:" || targetUrl.host !== targetAuthority) {
       clientReq.resume();
       clientRes.writeHead(403, { "content-type": "text/plain" });
-      clientRes.end("loopback blocked by proxy lab\n");
+      clientRes.end("blocked by proxy lab\n");
       events.push({ type: "deny", status: 403, url: targetUrl.toString() });
       return;
     }
 
     const upstreamReq = originalHttpRequest(
-      targetUrl,
       {
+        protocol: "http:",
+        hostname: targetHost,
+        port: targetAddress.port,
+        path: `${targetUrl.pathname}${targetUrl.search}`,
         method: clientReq.method,
         agent: upstreamDirectAgent,
         headers: {
           ...clientReq.headers,
-          host: targetUrl.host,
+          host: targetAuthority,
         },
       },
       (upstreamRes) => {
@@ -276,7 +269,7 @@ export async function startProxyLab(options: ProxyLabOptions = {}): Promise<Prox
       return;
     }
 
-    if (isLoopbackHost(targetHost) && !allowLoopbackAuthorities.has(authority)) {
+    if (!allowLoopbackAuthorities.has(authority)) {
       clientSocket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
       events.push({ type: "deny_connect", status: 403, authority, path: "<authority>" });
       return;


### PR DESCRIPTION
## What Problem This Solves

Fixes four fresh CodeQL alerts from default-setup run 32454538553:

- `js/polynomial-redos` in ambient `NO_PROXY` hostname normalization
- `js/disabling-certificate-validation` in TLS-isolation E2E coverage
- `js/request-forgery` in the local proxy lab
- `js/incomplete-multi-character-sanitization` in docs TOC generation

## Why This Change Was Made

The runtime now strips trailing hostname dots with a single linear scan. The proxy lab only forwards to its registered local target and rebuilds outbound requests from trusted listener state; CONNECT uses the same authority allowlist. TLS isolation is tested with distinct destination and proxy CAs instead of disabling verification, and TOC text extraction uses a character scanner instead of regex tag removal.

No dependencies, workflows, repository settings, or release configuration changed.

## User Impact

Ambient proxy resolution remains responsive for adversarial dot-heavy `NO_PROXY` input. Test and docs tooling no longer contain unsafe network or sanitization patterns, while preserving the existing proxy/TLS behavior.

## Evidence

- `tsc -p tsconfig.build.json`
- `tsc --noEmit`
- `tsx --test test/index.test.ts` (36 passed)
- `tsx --test test/e2e.test.ts` (77 passed)
- `tsx --test test/scripts.test.ts` (4 passed)
- `node scripts/run-coverage.mjs` (125 passed; 93.58% lines, 82.03% branches, 94.42% functions)
- `tsx --test test/package-artifact.test.ts` (1 passed)
- `node scripts/build-docs-site.mjs`
- `node scripts/prepack-build.mjs`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

Production/tooling delta: +25/-5 lines (`src/` and `scripts/`), justified by the input-processing and egress security invariants. Tests: +94/-17 lines. Changelog: +2 lines.

CodeQL and exact-head ClawSweeper results will be added after the draft checks complete.
