### PR TITLE
fix(http): default HTTP-forward connect timeout to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.8 - Unreleased
 
+- Fixed HTTP-forward Node agents to apply the default 30-second proxy connect timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.
+
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -421,6 +421,8 @@ class ProxylineHttpForwardAgent extends http.Agent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
   readonly #pendingConnectSockets = new Set<net.Socket>();
+  readonly #pendingRequests = new WeakMap<NodeAgentRequestOptions, http.ClientRequest>();
+  readonly #pendingRequestQueue: http.ClientRequest[] = [];
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
@@ -435,25 +437,87 @@ class ProxylineHttpForwardAgent extends http.Agent {
   public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
     setForwardProxyRequestPath(req as http.ClientRequest & { _header?: string | null }, options);
     setProxyRequestHeaders(req, this.#proxy, this.#keepAlive);
-    (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    this.#pendingRequests.set(options, req);
+    this.#pendingRequestQueue.push(req);
+    req.once("socket", () => this.#removePendingRequest(req));
+    req.once("close", () => this.#removePendingRequest(req));
+    try {
+      (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    } catch (error) {
+      this.#pendingRequests.delete(options);
+      this.#removePendingRequest(req);
+      throw error;
+    }
+  }
+
+  #removePendingRequest(req: http.ClientRequest): void {
+    const index = this.#pendingRequestQueue.indexOf(req);
+    if (index !== -1) {
+      this.#pendingRequestQueue.splice(index, 1);
+    }
   }
 
   public override createConnection(
-    _options: NodeAgentRequestOptions,
+    options: NodeAgentRequestOptions,
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
+    const mappedRequest = this.#pendingRequests.get(options);
+    const request = mappedRequest ?? this.#pendingRequestQueue.shift();
+    this.#pendingRequests.delete(options);
+    if (mappedRequest !== undefined) {
+      this.#removePendingRequest(mappedRequest);
+    }
     const socket = connectToProxy(this.#proxy, this.#proxyTls);
     // When Node supplies an async callback, deliver the socket only through that
     // path. Returning the same socket as well double-invokes Agent setup and can
     // hand an unready TLS proxy socket to plain HTTP forward traffic.
     if (callback !== undefined) {
       this.#pendingConnectSockets.add(socket);
+      let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
       let settled = false;
+      let originalRequestSetTimeout: RequestSetTimeout | undefined;
+      let hookedRequestSetTimeout: RequestSetTimeout | undefined;
+
+      const startPendingTimeout = (timeoutMs: number): void => {
+        if (pendingTimeout !== undefined) {
+          clearTimeout(pendingTimeout);
+        }
+        pendingTimeout = setTimeout(() => {
+          request?.emit("timeout");
+          if (!settled) {
+            fail(new ProxylineError("CONNECT_FAILED", "proxy connection timed out"));
+          }
+        }, timeoutMs);
+        pendingTimeout.unref?.();
+      };
+
+      const clearPendingTimeout = (): void => {
+        if (pendingTimeout !== undefined) {
+          clearTimeout(pendingTimeout);
+          pendingTimeout = undefined;
+        }
+      };
+
+      const restoreRequestTimeoutHook = (): void => {
+        if (
+          request !== undefined &&
+          originalRequestSetTimeout !== undefined &&
+          request.setTimeout === hookedRequestSetTimeout
+        ) {
+          request.setTimeout = originalRequestSetTimeout;
+        }
+        originalRequestSetTimeout = undefined;
+        hookedRequestSetTimeout = undefined;
+      };
+
       const cleanup = (): void => {
+        clearPendingTimeout();
         this.#pendingConnectSockets.delete(socket);
+        restoreRequestTimeoutHook();
         socket.off(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
         socket.off("error", onError);
         socket.off("close", onClosed);
+        request?.off("timeout", onRequestTimedOut);
       };
       const finish = (error: Error | null): void => {
         if (settled) {
@@ -462,6 +526,10 @@ class ProxylineHttpForwardAgent extends http.Agent {
         settled = true;
         cleanup();
         callback(error, socket);
+      };
+      const fail = (error: Error): void => {
+        socket.destroy();
+        finish(error);
       };
       const onError = (error: Error): void => {
         finish(error);
@@ -472,6 +540,45 @@ class ProxylineHttpForwardAgent extends http.Agent {
       const onConnected = (): void => {
         finish(null);
       };
+      const onRequestTimedOut = (): void => {
+        if (!settled) {
+          fail(new ProxylineError("CONNECT_FAILED", "proxy connection timed out"));
+        }
+      };
+
+      if (request !== undefined) {
+        originalRequestSetTimeout = request.setTimeout;
+        hookedRequestSetTimeout = function hookedSetTimeout(timeout, callback) {
+          const result = originalRequestSetTimeout?.call(this, timeout, callback) ?? this;
+          const timeoutMs = normalizedPositiveInteger(timeout);
+          if (timeoutMs !== undefined) {
+            startPendingTimeout(timeoutMs);
+          } else {
+            clearPendingTimeout();
+          }
+          return result;
+        };
+        request.setTimeout = hookedRequestSetTimeout;
+      }
+
+      // Prefer explicit agent/request timeout. Default 30s only when both are omitted.
+      // Explicit values go through normalizedPositiveInteger first so fractional/invalid
+      // timeouts keep the historical no-pending-timer behavior (not Math.trunc to 1ms).
+      const requestTimeout = (request as { timeout?: unknown } | undefined)?.timeout;
+      const rawTimeout = options.timeout !== undefined ? options.timeout : requestTimeout;
+      if (rawTimeout === undefined) {
+        const connectTimeoutMs = resolveProxyConnectTimeoutMs(undefined);
+        if (connectTimeoutMs !== undefined) {
+          startPendingTimeout(connectTimeoutMs);
+        }
+      } else {
+        const timeoutMs = normalizedPositiveInteger(rawTimeout);
+        if (timeoutMs !== undefined) {
+          startPendingTimeout(timeoutMs);
+        }
+      }
+      request?.once("timeout", onRequestTimedOut);
+
       socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
       socket.once("error", onError);
       socket.once("close", onClosed);

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -850,6 +850,147 @@ test("node HTTP-forward agent destroys pending proxy sockets when the agent is d
   });
 });
 
+test("node HTTP-forward agent defaults omitted timeout to 30 seconds", async (t) => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const observedTimeouts: number[] = [];
+  t.mock.method(
+    globalThis,
+    "setTimeout",
+    ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+      observedTimeouts.push(delay ?? 0);
+      return originalSetTimeout(callback, delay === 30_000 ? 20 : delay, ...args);
+    }) as typeof setTimeout,
+  );
+
+  await withStalledTlsProxy(async (proxyUrl) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    try {
+      await assert.rejects(
+        new Promise<void>((resolve, reject) => {
+          const req = http.get("http://example.test/allowed", { agent }, () => {
+            resolve();
+          });
+          req.on("error", reject);
+        }),
+        /timed out/,
+      );
+    } finally {
+      agent.destroy();
+    }
+  });
+  assert.ok(
+    observedTimeouts.includes(30_000),
+    `expected a 30s HTTP-forward connect timeout, got ${JSON.stringify(observedTimeouts)}`,
+  );
+});
+
+test("node HTTP-forward agent times out stalled proxy handshakes", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    try {
+      await assert.rejects(
+        new Promise<void>((resolve, reject) => {
+          const req = http.get("http://example.test/allowed", { agent, timeout: 50 }, () => {
+            resolve();
+          });
+          req.on("error", reject);
+        }),
+        /timed out/,
+      );
+      for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
+test("node HTTP-forward agent honors req.setTimeout during stalled proxy handshakes", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    try {
+      await assert.rejects(
+        new Promise<void>((resolve, reject) => {
+          const req = http.get("http://example.test/allowed", { agent }, () => {
+            resolve();
+          });
+          req.setTimeout(50, () => {
+            req.destroy(new Error("late request timeout"));
+          });
+          req.on("error", reject);
+        }),
+        /timeout|timed out/,
+      );
+      for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
+test("node HTTP-forward agent clears pending timeouts when req.setTimeout disables them", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    const req = http.get("http://example.test/allowed", { agent, timeout: 50 }, () => {});
+    let requestError: Error | undefined;
+    req.on("error", (error) => {
+      requestError = error;
+    });
+    try {
+      req.setTimeout(0);
+      for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 1);
+
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      assert.equal(requestError, undefined);
+      assert.equal(activeSockets.size, 1);
+    } finally {
+      req.destroy();
+      agent.destroy();
+    }
+  });
+});
+
 test("node CONNECT agent fails requests when destination TLS closes during handshake", async () => {
   const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
   const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };


### PR DESCRIPTION
## What Problem This Solves

Plain HTTP traffic through Proxyline uses `ProxylineHttpForwardAgent`, not the CONNECT tunnel. That agent waited for the proxy `connect` or `secureConnect` event and never started a pending timer. If the proxy never completed the handshake, `http.get("http://...")` hung. Caller `timeout` and `req.setTimeout()` also did not apply until Node received the socket.

HTTPS CONNECT already defaults omitted timeouts to 30 seconds (#19 and #17). HTTP-forward did not. `createNodeAgent()`, `createAmbientNodeProxyAgent()`, and `installProxyline` all share this path for `http://` destinations.

## Evidence

**Before (unpatched `createConnection`):** a stalled HTTPS proxy never emits `secureConnect`. A public `http.get("http://example.test/allowed")` with no request timeout stays pending past the 4s harness limit.

```console
$ pnpm exec tsx --test --test-timeout 4000 --test-name-pattern 'node HTTP-forward agent defaults omitted timeout' test/e2e.test.ts
✖ node HTTP-forward agent defaults omitted timeout to 30 seconds (4000.918458ms)
```

**After (this patch):** the same public path schedules the shared 30s default, honors `{ timeout: 80 }` and `req.setTimeout()`, and fails with `proxy connection timed out`. Live `node` against `installProxyline`, `createNodeAgent()`, and `createAmbientNodeProxyAgent()`:

```console
$ node /tmp/proxyline-F006-proof.mjs
proxyUrl https://127.0.0.1:63357
omitted.ok false
omitted.ms 36
omitted.error proxy connection timed out
defaultTimerMs 30000
explicit.ok false
explicit.ms 82
explicit.error proxy connection timed out
helper.ok false
helper.ms 81
helper.error proxy connection timed out
ambient.ok false
ambient.ms 82
ambient.error proxy connection timed out
```

Sibling CONNECT-only timeouts: https://github.com/openclaw/proxyline/pull/19 and https://github.com/openclaw/proxyline/pull/17. #23 destroys pending forward sockets on `agent.destroy()` only; it does not start a connect timer.

## Real behavior proof

- **Behavior or issue addressed:** HTTP-forward proxy connect/TLS handshake had no default timeout, so a blackholed or stalled proxy hung `http.get("http://...")` and ignored caller timeout until the socket was handed off.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, proxyline `fix/f006-forward-connect-timeout` built from `/tmp/oc-pr-proxyline-F006`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-pr-proxyline-F006
  pnpm build
  node /tmp/proxyline-F006-proof.mjs
  ```

- **Evidence after fix:** terminal output from the live `node` script above. The omitted-timeout case recorded `defaultTimerMs 30000` and failed in 36ms after the 30s timer was remapped for the demo. Explicit 80ms `timeout` on patched `http.get`, `handle.createNodeAgent()`, and `createAmbientNodeProxyAgent()` each failed in 81-82ms with `proxy connection timed out`.
- **Observed result after fix:** Public HTTP-forward APIs now apply the same 30s default as CONNECT (`resolveProxyConnectTimeoutMs`). Request `timeout` and `req.setTimeout()` start the pending timer before the proxy handshake completes. Explicit `0` still disables the timer.
- **What was not tested:** undici dispatcher HTTP-forward, a routable blackhole IP that never SYN-ACKs, and request abort while the handshake is still pending.
- **Command:** `node /tmp/proxyline-F006-proof.mjs`
- **Observed:** `omitted.error proxy connection timed out` with `defaultTimerMs 30000`; explicit 80ms paths failed in 81-82ms.
- **Expected:** omitted timeout uses 30000ms; short request timeout fails near 80ms; helper and ambient agents match.
- **Time:** 18:12:13Z
- **Date:** 2026-08-29
- **Environment:** Darwin 25.6.0 arm64, Node v26.7.0

## Summary

This is the HTTP-forward counterpart of #19. `ProxylineHttpForwardAgent.createConnection` now starts `resolveProxyConnectTimeoutMs` when both agent and request timeouts are omitted, honors a positive request/agent timeout, and hooks `req.setTimeout` the same way as `ProxylineConnectAgent`. Request abort cancellation is left for a follow-up.

The hang was introduced with the original Node agent in [#4](https://github.com/openclaw/proxyline/pull/4) ([`98a53119`](https://github.com/openclaw/proxyline/commit/98a53119), 2026-05-14).
