### PR TITLE
fix(http): cancel pending forward sockets on request abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.8 - Unreleased
 
+- Fixed HTTP-forward Node agents to cancel pending proxy sockets when the caller aborts or destroys the request during the handshake. Thanks @SebTardif.
+
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -30,6 +30,7 @@ type RequestSetTimeout = (
   timeout: number,
   callback?: () => void,
 ) => http.ClientRequest;
+type RequestDestroy = (this: http.ClientRequest, error?: Error) => http.ClientRequest;
 type NodeAgentWithOptions = http.Agent & {
   options?: NodeAgentOptions;
 };
@@ -421,6 +422,8 @@ class ProxylineHttpForwardAgent extends http.Agent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
   readonly #pendingConnectSockets = new Set<net.Socket>();
+  readonly #pendingRequests = new WeakMap<NodeAgentRequestOptions, http.ClientRequest>();
+  readonly #pendingRequestQueue: http.ClientRequest[] = [];
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
@@ -435,13 +438,36 @@ class ProxylineHttpForwardAgent extends http.Agent {
   public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
     setForwardProxyRequestPath(req as http.ClientRequest & { _header?: string | null }, options);
     setProxyRequestHeaders(req, this.#proxy, this.#keepAlive);
-    (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    this.#pendingRequests.set(options, req);
+    this.#pendingRequestQueue.push(req);
+    req.once("socket", () => this.#removePendingRequest(req));
+    req.once("close", () => this.#removePendingRequest(req));
+    try {
+      (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    } catch (error) {
+      this.#pendingRequests.delete(options);
+      this.#removePendingRequest(req);
+      throw error;
+    }
+  }
+
+  #removePendingRequest(req: http.ClientRequest): void {
+    const index = this.#pendingRequestQueue.indexOf(req);
+    if (index !== -1) {
+      this.#pendingRequestQueue.splice(index, 1);
+    }
   }
 
   public override createConnection(
-    _options: NodeAgentRequestOptions,
+    options: NodeAgentRequestOptions,
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
+    const mappedRequest = this.#pendingRequests.get(options);
+    const request = mappedRequest ?? this.#pendingRequestQueue.shift();
+    this.#pendingRequests.delete(options);
+    if (mappedRequest !== undefined) {
+      this.#removePendingRequest(mappedRequest);
+    }
     const socket = connectToProxy(this.#proxy, this.#proxyTls);
     // When Node supplies an async callback, deliver the socket only through that
     // path. Returning the same socket as well double-invokes Agent setup and can
@@ -449,11 +475,28 @@ class ProxylineHttpForwardAgent extends http.Agent {
     if (callback !== undefined) {
       this.#pendingConnectSockets.add(socket);
       let settled = false;
+      let originalRequestDestroy: RequestDestroy | undefined;
+      let hookedRequestDestroy: RequestDestroy | undefined;
+      const restoreRequestDestroyHook = (): void => {
+        if (
+          request !== undefined &&
+          originalRequestDestroy !== undefined &&
+          request.destroy === hookedRequestDestroy
+        ) {
+          request.destroy = originalRequestDestroy;
+        }
+        originalRequestDestroy = undefined;
+        hookedRequestDestroy = undefined;
+      };
       const cleanup = (): void => {
         this.#pendingConnectSockets.delete(socket);
+        restoreRequestDestroyHook();
         socket.off(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
         socket.off("error", onError);
         socket.off("close", onClosed);
+        request?.off("abort", onRequestClosed);
+        request?.off("close", onRequestClosed);
+        request?.off("error", onRequestClosed);
       };
       const finish = (error: Error | null): void => {
         if (settled) {
@@ -462,6 +505,10 @@ class ProxylineHttpForwardAgent extends http.Agent {
         settled = true;
         cleanup();
         callback(error, socket);
+      };
+      const fail = (error: Error): void => {
+        socket.destroy();
+        finish(error);
       };
       const onError = (error: Error): void => {
         finish(error);
@@ -472,9 +519,30 @@ class ProxylineHttpForwardAgent extends http.Agent {
       const onConnected = (): void => {
         finish(null);
       };
+      const onRequestClosed = (): void => {
+        if (!settled) {
+          fail(new ProxylineError("CONNECT_FAILED", "request closed before proxy connection completed"));
+        }
+      };
       socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
       socket.once("error", onError);
       socket.once("close", onClosed);
+      // Node defers ClientRequest.destroy() until the async socket callback.
+      if (request !== undefined) {
+        originalRequestDestroy = request.destroy;
+        hookedRequestDestroy = function hookedDestroy(this: http.ClientRequest, error?: Error) {
+          const result = originalRequestDestroy?.call(this, error) ?? this;
+          onRequestClosed();
+          return result;
+        };
+        request.destroy = hookedRequestDestroy;
+      }
+      request?.once("abort", onRequestClosed);
+      request?.once("close", onRequestClosed);
+      request?.once("error", onRequestClosed);
+      if (request?.destroyed) {
+        onRequestClosed();
+      }
       return undefined as unknown as net.Socket;
     }
     return socket;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -850,6 +850,56 @@ test("node HTTP-forward agent destroys pending proxy sockets when the agent is d
   });
 });
 
+test("node HTTP-forward helper agents cancel pending sockets when the request is aborted", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const originalHttpGet = http.get;
+    const handle = installGlobalProxy({ mode: "managed", proxyUrl });
+    const helperAgent = handle.createNodeAgent();
+    const ambientAgent = withProxyEnv({ HTTP_PROXY: proxyUrl, ALL_PROXY: proxyUrl }, () =>
+      createAmbientNodeProxyAgent({ protocol: "http" }),
+    );
+    assert.ok(ambientAgent);
+
+    const assertAbortCancelsPendingSocket = async (agent: http.Agent): Promise<void> => {
+      const req = originalHttpGet("http://example.test/allowed", { agent }, () => {});
+      const requestClosed = new Promise<void>((resolve) => {
+        req.once("error", () => resolve());
+        req.once("close", () => resolve());
+      });
+      try {
+        for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        assert.equal(activeSockets.size, 1);
+
+        req.destroy();
+
+        await Promise.race([
+          requestClosed,
+          new Promise<never>((_resolve, reject) => {
+            setTimeout(() => reject(new Error("request remained pending after abort")), 500);
+          }),
+        ]);
+        for (let attempt = 0; attempt < 80 && activeSockets.size > 0; attempt += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        assert.equal(activeSockets.size, 0);
+      } finally {
+        req.destroy();
+      }
+    };
+
+    try {
+      await assertAbortCancelsPendingSocket(helperAgent);
+      await assertAbortCancelsPendingSocket(ambientAgent);
+    } finally {
+      helperAgent.destroy();
+      ambientAgent.destroy();
+      handle.stop();
+    }
+  });
+});
+
 test("node CONNECT agent fails requests when destination TLS closes during handshake", async () => {
   const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
   const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };


### PR DESCRIPTION
## What Problem This Solves

Plain HTTP traffic through a long-lived helper agent uses `ProxylineHttpForwardAgent`. That agent tracked pending sockets for `agent.destroy()` (#23) but did not watch the request. `req.destroy()` while the proxy handshake is still pending left the TCP/TLS connect running.

HTTPS CONNECT already cancels the pending socket when the request closes. HTTP-forward did not. `handle.createNodeAgent()` and `createAmbientNodeProxyAgent()` share this path for `http://` destinations.

Node also defers `ClientRequest.destroy()` until the async `createConnection` callback, so `abort` / `close` / `error` do not fire in time. This patch hooks `request.destroy` as well as those events and `fail()`s the pending socket.

## Evidence

**Before (unpatched `createConnection`):** a stalled HTTPS proxy never emits `secureConnect`. Public `createAmbientNodeProxyAgent()` / `handle.createNodeAgent()` plus `http.get(..., { agent })` and `req.destroy()` left the proxy socket open and the request pending.

```console
$ pnpm exec tsx --test --test-timeout 15000 --test-name-pattern 'node HTTP-forward helper agents cancel pending sockets' test/e2e.test.ts
✖ node HTTP-forward helper agents cancel pending sockets when the request is aborted (544.03075ms)
  Error: request remained pending after abort
```

**After (this patch):** the same public path destroys the pending socket and fails the request with `request closed before proxy connection completed`. Live `node` against `createAmbientNodeProxyAgent()` and `handle.createNodeAgent()`:

```console
$ node /tmp/proxyline-F007-proof.mjs
proxyUrl https://127.0.0.1:60075
ambient.socketsBefore 1
ambient.socketsAfter 0
ambient.request request closed before proxy connection completed
ambient.destroyed true
helper.socketsBefore 1
helper.socketsAfter 0
helper.request request closed before proxy connection completed
helper.destroyed true
```

Sibling cleanup: https://github.com/openclaw/proxyline/pull/23 destroys pending forward sockets on `agent.destroy()` only. https://github.com/openclaw/proxyline/pull/25 is the connect-timeout counterpart and leaves request abort for this follow-up. CONNECT caller cancellation: https://github.com/openclaw/proxyline/pull/12.

## Real behavior proof

- **Behavior or issue addressed:** HTTP-forward helper agents left the proxy TCP/TLS connect running after `req.destroy()` during a pending handshake.
- **Real environment tested:** macOS Darwin 25.6.0 arm64, Node v26.7.0, proxyline `fix/f007-forward-abort-cancel` built from `/tmp/oc-pr-proxyline-F007`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-pr-proxyline-F007
  pnpm exec tsc -p tsconfig.build.json
  node /tmp/proxyline-F007-proof.mjs
  ```

- **Evidence after fix:** terminal output from the live `node` script above. Both `createAmbientNodeProxyAgent()` and `handle.createNodeAgent()` recorded `socketsBefore 1`, `socketsAfter 0`, and `request closed before proxy connection completed`.
- **Observed result after fix:** Public HTTP-forward helper APIs now cancel the pending proxy socket when the caller destroys the request. The request fails instead of staying pending until `agent.destroy()` or a later handshake event.
- **What was not tested:** undici dispatcher HTTP-forward, and `req.abort()` on Node versions that only emit the deprecated abort event without going through `destroy`.

## Summary

This is the HTTP-forward counterpart of CONNECT request cancellation. `ProxylineHttpForwardAgent.createConnection` now maps the pending `http.ClientRequest`, listens for abort/close/error, hooks `request.destroy` (Node defers destroy until the socket callback), and `fail()`s the pending socket.

The hang was introduced with the original Node agent in [#4](https://github.com/openclaw/proxyline/pull/4) ([`98a53119`](https://github.com/openclaw/proxyline/commit/98a53119), 2026-05-14). #23 closed the `agent.destroy()` path only.
