### PR TITLE
fix(http): isolate pending proxy timeouts and cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.8 - Unreleased
 
+- Fixed HTTP-forward Node agents to cancel pending proxy sockets when the caller aborts or destroys the request during the handshake. Thanks @SebTardif.
+
 ## 0.3.7 - 2026-08-02
 
 - Fixed Node HTTP/HTTPS proxy agents to apply the default 30-second CONNECT timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.3.8 - Unreleased
 
 - Fixed HTTP-forward Node agents to cancel pending proxy sockets when the caller aborts or destroys the request during the handshake. Thanks @SebTardif.
+- Fixed HTTP-forward Node agents to apply the default 30-second proxy connect timeout when callers omit a request timeout; explicit `0` remains unbounded. Thanks @SebTardif.
+- Fixed Node proxy request hooks to follow the selected request when finite connection pools queue requests across origins.
 
 ## 0.3.7 - 2026-08-02
 

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -22,6 +22,10 @@ Per request, Proxyline:
 
 This means caller agents are not just ignored — the per-request agent is replaced before the original method runs, so even libraries that read `req.agent` after construction see the proxy agent.
 
+HTTP-forward proxy connections and CONNECT handshakes default to a 30-second connection timeout. A request's `timeout` option or `req.setTimeout(ms)` can change the pending handshake timeout; use `0` to leave it unbounded. Expiry emits `timeout` on that request and fails the pending connection with `CONNECT_FAILED`. This applies to the explicit Node helper agents as well as patched requests.
+
+For HTTP-forward requests, `req.destroy()` or `req.abort()` also cancels a pending connection to the proxy. This applies to long-lived helper agents: cancellation releases the pending socket without destroying the whole agent or affecting another queued request.
+
 ### TLS identity preservation
 
 When the caller supplied an `https.Agent` with TLS options, the following keys are lifted into the request so the destination TLS handshake still validates correctly:

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -30,6 +30,7 @@ type RequestSetTimeout = (
   timeout: number,
   callback?: () => void,
 ) => http.ClientRequest;
+type RequestDestroy = (this: http.ClientRequest, error?: Error) => http.ClientRequest;
 type NodeAgentWithOptions = http.Agent & {
   options?: NodeAgentOptions;
 };
@@ -421,6 +422,8 @@ class ProxylineHttpForwardAgent extends http.Agent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
   readonly #pendingConnectSockets = new Set<net.Socket>();
+  readonly #pendingRequests = new WeakMap<NodeAgentRequestOptions, http.ClientRequest>();
+  readonly #pendingRequestQueue: http.ClientRequest[] = [];
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
@@ -435,13 +438,36 @@ class ProxylineHttpForwardAgent extends http.Agent {
   public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
     setForwardProxyRequestPath(req as http.ClientRequest & { _header?: string | null }, options);
     setProxyRequestHeaders(req, this.#proxy, this.#keepAlive);
-    (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    this.#pendingRequests.set(options, req);
+    this.#pendingRequestQueue.push(req);
+    req.once("socket", () => this.#removePendingRequest(req));
+    req.once("close", () => this.#removePendingRequest(req));
+    try {
+      (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+    } catch (error) {
+      this.#pendingRequests.delete(options);
+      this.#removePendingRequest(req);
+      throw error;
+    }
+  }
+
+  #removePendingRequest(req: http.ClientRequest): void {
+    const index = this.#pendingRequestQueue.indexOf(req);
+    if (index !== -1) {
+      this.#pendingRequestQueue.splice(index, 1);
+    }
   }
 
   public override createConnection(
-    _options: NodeAgentRequestOptions,
+    options: NodeAgentRequestOptions,
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
+    const mappedRequest = this.#pendingRequests.get(options);
+    const request = mappedRequest ?? this.#pendingRequestQueue.shift();
+    this.#pendingRequests.delete(options);
+    if (mappedRequest !== undefined) {
+      this.#removePendingRequest(mappedRequest);
+    }
     const socket = connectToProxy(this.#proxy, this.#proxyTls);
     // When Node supplies an async callback, deliver the socket only through that
     // path. Returning the same socket as well double-invokes Agent setup and can
@@ -449,11 +475,28 @@ class ProxylineHttpForwardAgent extends http.Agent {
     if (callback !== undefined) {
       this.#pendingConnectSockets.add(socket);
       let settled = false;
+      let originalRequestDestroy: RequestDestroy | undefined;
+      let hookedRequestDestroy: RequestDestroy | undefined;
+      const restoreRequestDestroyHook = (): void => {
+        if (
+          request !== undefined &&
+          originalRequestDestroy !== undefined &&
+          request.destroy === hookedRequestDestroy
+        ) {
+          request.destroy = originalRequestDestroy;
+        }
+        originalRequestDestroy = undefined;
+        hookedRequestDestroy = undefined;
+      };
       const cleanup = (): void => {
         this.#pendingConnectSockets.delete(socket);
+        restoreRequestDestroyHook();
         socket.off(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
         socket.off("error", onError);
         socket.off("close", onClosed);
+        request?.off("abort", onRequestClosed);
+        request?.off("close", onRequestClosed);
+        request?.off("error", onRequestClosed);
       };
       const finish = (error: Error | null): void => {
         if (settled) {
@@ -462,6 +505,10 @@ class ProxylineHttpForwardAgent extends http.Agent {
         settled = true;
         cleanup();
         callback(error, socket);
+      };
+      const fail = (error: Error): void => {
+        socket.destroy();
+        finish(error);
       };
       const onError = (error: Error): void => {
         finish(error);
@@ -472,9 +519,30 @@ class ProxylineHttpForwardAgent extends http.Agent {
       const onConnected = (): void => {
         finish(null);
       };
+      const onRequestClosed = (): void => {
+        if (!settled) {
+          fail(new ProxylineError("CONNECT_FAILED", "request closed before proxy connection completed"));
+        }
+      };
       socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
       socket.once("error", onError);
       socket.once("close", onClosed);
+      // Node defers ClientRequest.destroy() until the async socket callback.
+      if (request !== undefined) {
+        originalRequestDestroy = request.destroy;
+        hookedRequestDestroy = function hookedDestroy(this: http.ClientRequest, error?: Error) {
+          const result = originalRequestDestroy?.call(this, error) ?? this;
+          onRequestClosed();
+          return result;
+        };
+        request.destroy = hookedRequestDestroy;
+      }
+      request?.once("abort", onRequestClosed);
+      request?.once("close", onRequestClosed);
+      request?.once("error", onRequestClosed);
+      if (request?.destroyed) {
+        onRequestClosed();
+      }
       return undefined as unknown as net.Socket;
     }
     return socket;

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -19,11 +19,20 @@ export type NodeHttpRequestOptions = http.RequestOptions & https.RequestOptions 
 type NodeHttpMethod = typeof http.request;
 type NodeAgentFactory = (options: NodeHttpRequestOptions) => http.Agent;
 type NodeAgentOptions = http.AgentOptions & https.AgentOptions;
+const pendingRequestSymbol = Symbol("proxyline.pendingRequest");
 type NodeAgentRequestOptions = http.RequestOptions & https.RequestOptions & {
   secureEndpoint?: boolean;
+  [pendingRequestSymbol]?: http.ClientRequest;
 };
 type NodeAddRequestAgent = http.Agent & {
   addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void;
+};
+type NodeCreateSocketAgent = http.Agent & {
+  createSocket(
+    req: http.ClientRequest,
+    options: NodeAgentRequestOptions,
+    callback: (error: Error | null, socket?: net.Socket) => void,
+  ): void;
 };
 type RequestSetTimeout = (
   this: http.ClientRequest,
@@ -418,12 +427,34 @@ function destinationTlsConnectOptions(
   return tlsOptions;
 }
 
-class ProxylineHttpForwardAgent extends http.Agent {
+abstract class ProxylineRequestAgent extends http.Agent {
+  public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
+    (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
+  }
+
+  public createSocket(
+    req: http.ClientRequest,
+    options: NodeAgentRequestOptions,
+    callback: (error: Error | null, socket?: net.Socket) => void,
+  ): void {
+    // Node chooses queued requests by origin, not global FIFO, and clones options.
+    (http.Agent.prototype as unknown as NodeCreateSocketAgent).createSocket.call(
+      this, req, { ...options, [pendingRequestSymbol]: req }, callback,
+    );
+  }
+
+  protected takePendingRequest(options: NodeAgentRequestOptions): http.ClientRequest | undefined {
+    const request = options[pendingRequestSymbol];
+    // Node retains these options in pooled socket listeners after handoff.
+    delete options[pendingRequestSymbol];
+    return request;
+  }
+}
+
+class ProxylineHttpForwardAgent extends ProxylineRequestAgent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
   readonly #pendingConnectSockets = new Set<net.Socket>();
-  readonly #pendingRequests = new WeakMap<NodeAgentRequestOptions, http.ClientRequest>();
-  readonly #pendingRequestQueue: http.ClientRequest[] = [];
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
@@ -435,48 +466,30 @@ class ProxylineHttpForwardAgent extends http.Agent {
     this.#proxyTls = proxyTls;
   }
 
-  public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
+  public override addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
     setForwardProxyRequestPath(req as http.ClientRequest & { _header?: string | null }, options);
     setProxyRequestHeaders(req, this.#proxy, this.#keepAlive);
-    this.#pendingRequests.set(options, req);
-    this.#pendingRequestQueue.push(req);
-    req.once("socket", () => this.#removePendingRequest(req));
-    req.once("close", () => this.#removePendingRequest(req));
-    try {
-      (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
-    } catch (error) {
-      this.#pendingRequests.delete(options);
-      this.#removePendingRequest(req);
-      throw error;
-    }
-  }
-
-  #removePendingRequest(req: http.ClientRequest): void {
-    const index = this.#pendingRequestQueue.indexOf(req);
-    if (index !== -1) {
-      this.#pendingRequestQueue.splice(index, 1);
-    }
+    super.addRequest(req, options);
   }
 
   public override createConnection(
     options: NodeAgentRequestOptions,
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
-    const mappedRequest = this.#pendingRequests.get(options);
-    const request = mappedRequest ?? this.#pendingRequestQueue.shift();
-    this.#pendingRequests.delete(options);
-    if (mappedRequest !== undefined) {
-      this.#removePendingRequest(mappedRequest);
-    }
+    const request = this.takePendingRequest(options);
     const socket = connectToProxy(this.#proxy, this.#proxyTls);
     // When Node supplies an async callback, deliver the socket only through that
     // path. Returning the same socket as well double-invokes Agent setup and can
     // hand an unready TLS proxy socket to plain HTTP forward traffic.
     if (callback !== undefined) {
       this.#pendingConnectSockets.add(socket);
+      let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
       let settled = false;
+      let originalRequestSetTimeout: RequestSetTimeout | undefined;
+      let hookedRequestSetTimeout: RequestSetTimeout | undefined;
       let originalRequestDestroy: RequestDestroy | undefined;
       let hookedRequestDestroy: RequestDestroy | undefined;
+
       const restoreRequestDestroyHook = (): void => {
         if (
           request !== undefined &&
@@ -488,8 +501,43 @@ class ProxylineHttpForwardAgent extends http.Agent {
         originalRequestDestroy = undefined;
         hookedRequestDestroy = undefined;
       };
+
+      const startPendingTimeout = (timeoutMs: number): void => {
+        if (pendingTimeout !== undefined) {
+          clearTimeout(pendingTimeout);
+        }
+        pendingTimeout = setTimeout(() => {
+          request?.emit("timeout");
+          if (!settled) {
+            fail(new ProxylineError("CONNECT_FAILED", "proxy connection timed out"));
+          }
+        }, timeoutMs);
+        pendingTimeout.unref?.();
+      };
+
+      const clearPendingTimeout = (): void => {
+        if (pendingTimeout !== undefined) {
+          clearTimeout(pendingTimeout);
+          pendingTimeout = undefined;
+        }
+      };
+
+      const restoreRequestTimeoutHook = (): void => {
+        if (
+          request !== undefined &&
+          originalRequestSetTimeout !== undefined &&
+          request.setTimeout === hookedRequestSetTimeout
+        ) {
+          request.setTimeout = originalRequestSetTimeout;
+        }
+        originalRequestSetTimeout = undefined;
+        hookedRequestSetTimeout = undefined;
+      };
+
       const cleanup = (): void => {
+        clearPendingTimeout();
         this.#pendingConnectSockets.delete(socket);
+        restoreRequestTimeoutHook();
         restoreRequestDestroyHook();
         socket.off(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
         socket.off("error", onError);
@@ -497,6 +545,7 @@ class ProxylineHttpForwardAgent extends http.Agent {
         request?.off("abort", onRequestClosed);
         request?.off("close", onRequestClosed);
         request?.off("error", onRequestClosed);
+        request?.off("timeout", onRequestTimedOut);
       };
       const finish = (error: Error | null): void => {
         if (settled) {
@@ -519,11 +568,50 @@ class ProxylineHttpForwardAgent extends http.Agent {
       const onConnected = (): void => {
         finish(null);
       };
+      const onRequestTimedOut = (): void => {
+        if (!settled) {
+          fail(new ProxylineError("CONNECT_FAILED", "proxy connection timed out"));
+        }
+      };
       const onRequestClosed = (): void => {
         if (!settled) {
           fail(new ProxylineError("CONNECT_FAILED", "request closed before proxy connection completed"));
         }
       };
+
+      if (request !== undefined) {
+        originalRequestSetTimeout = request.setTimeout;
+        hookedRequestSetTimeout = function hookedSetTimeout(timeout, callback) {
+          const result = originalRequestSetTimeout?.call(this, timeout, callback) ?? this;
+          const timeoutMs = normalizedPositiveInteger(timeout);
+          if (timeoutMs !== undefined) {
+            startPendingTimeout(timeoutMs);
+          } else {
+            clearPendingTimeout();
+          }
+          return result;
+        };
+        request.setTimeout = hookedRequestSetTimeout;
+      }
+
+      // Prefer explicit agent/request timeout. Default 30s only when both are omitted.
+      // Explicit values go through normalizedPositiveInteger first so fractional/invalid
+      // timeouts keep the historical no-pending-timer behavior (not Math.trunc to 1ms).
+      const requestTimeout = (request as { timeout?: unknown } | undefined)?.timeout;
+      const rawTimeout = options.timeout !== undefined ? options.timeout : requestTimeout;
+      if (rawTimeout === undefined) {
+        const connectTimeoutMs = resolveProxyConnectTimeoutMs(undefined);
+        if (connectTimeoutMs !== undefined) {
+          startPendingTimeout(connectTimeoutMs);
+        }
+      } else {
+        const timeoutMs = normalizedPositiveInteger(rawTimeout);
+        if (timeoutMs !== undefined) {
+          startPendingTimeout(timeoutMs);
+        }
+      }
+      request?.once("timeout", onRequestTimedOut);
+
       socket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
       socket.once("error", onError);
       socket.once("close", onClosed);
@@ -557,12 +645,10 @@ class ProxylineHttpForwardAgent extends http.Agent {
   }
 }
 
-class ProxylineConnectAgent extends http.Agent {
+class ProxylineConnectAgent extends ProxylineRequestAgent {
   public readonly options: NodeAgentOptions;
   readonly #keepAlive: boolean;
   readonly #pendingConnectSockets = new Set<net.Socket>();
-  readonly #pendingRequests = new WeakMap<NodeAgentRequestOptions, http.ClientRequest>();
-  readonly #pendingRequestQueue: http.ClientRequest[] = [];
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
 
@@ -574,37 +660,11 @@ class ProxylineConnectAgent extends http.Agent {
     this.#proxyTls = proxyTls;
   }
 
-  public addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
-    this.#pendingRequests.set(options, req);
-    this.#pendingRequestQueue.push(req);
-    req.once("socket", () => this.#removePendingRequest(req));
-    req.once("close", () => this.#removePendingRequest(req));
-    try {
-      (http.Agent.prototype as unknown as NodeAddRequestAgent).addRequest.call(this, req, options);
-    } catch (error) {
-      this.#pendingRequests.delete(options);
-      this.#removePendingRequest(req);
-      throw error;
-    }
-  }
-
-  #removePendingRequest(req: http.ClientRequest): void {
-    const index = this.#pendingRequestQueue.indexOf(req);
-    if (index !== -1) {
-      this.#pendingRequestQueue.splice(index, 1);
-    }
-  }
-
   public override createConnection(
     options: NodeAgentRequestOptions,
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
-    const mappedRequest = this.#pendingRequests.get(options);
-    const request = mappedRequest ?? this.#pendingRequestQueue.shift();
-    this.#pendingRequests.delete(options);
-    if (mappedRequest !== undefined) {
-      this.#removePendingRequest(mappedRequest);
-    }
+    const request = this.takePendingRequest(options);
     if (callback === undefined) {
       throw new ProxylineError("INVALID_CONNECT_CALLBACK", "CONNECT agents require an async socket callback.");
     }

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -19,6 +19,7 @@ import {
 import { createNodeProxyAgent } from "../src/node-http.js";
 import type { ProxyResolver } from "../src/types.js";
 import { startProxyLab } from "./support/proxy-lab.js";
+import { createProxyTestCertificate } from "./support/proxy-cert.js";
 
 function withProxyEnv<T>(env: Record<string, string | undefined>, run: () => T): T {
   const keys = [
@@ -850,6 +851,147 @@ test("node HTTP-forward agent destroys pending proxy sockets when the agent is d
   });
 });
 
+test("node HTTP-forward agent defaults omitted timeout to 30 seconds", async (t) => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const observedTimeouts: number[] = [];
+  t.mock.method(
+    globalThis,
+    "setTimeout",
+    ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+      observedTimeouts.push(delay ?? 0);
+      return originalSetTimeout(callback, delay === 30_000 ? 20 : delay, ...args);
+    }) as typeof setTimeout,
+  );
+
+  await withStalledTlsProxy(async (proxyUrl) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    try {
+      await assert.rejects(
+        new Promise<void>((resolve, reject) => {
+          const req = http.get("http://example.test/allowed", { agent }, () => {
+            resolve();
+          });
+          req.on("error", reject);
+        }),
+        /timed out/,
+      );
+    } finally {
+      agent.destroy();
+    }
+  });
+  assert.ok(
+    observedTimeouts.includes(30_000),
+    `expected a 30s HTTP-forward connect timeout, got ${JSON.stringify(observedTimeouts)}`,
+  );
+});
+
+test("node HTTP-forward agent times out stalled proxy handshakes", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    try {
+      await assert.rejects(
+        new Promise<void>((resolve, reject) => {
+          const req = http.get("http://example.test/allowed", { agent, timeout: 50 }, () => {
+            resolve();
+          });
+          req.on("error", reject);
+        }),
+        /timed out/,
+      );
+      for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
+test("node HTTP-forward agent honors req.setTimeout during stalled proxy handshakes", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    try {
+      await assert.rejects(
+        new Promise<void>((resolve, reject) => {
+          const req = http.get("http://example.test/allowed", { agent }, () => {
+            resolve();
+          });
+          req.setTimeout(50, () => {
+            req.destroy(new Error("late request timeout"));
+          });
+          req.on("error", reject);
+        }),
+        /timeout|timed out/,
+      );
+      for (let attempt = 0; attempt < 20 && activeSockets.size > 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 0);
+    } finally {
+      agent.destroy();
+    }
+  });
+});
+
+test("node HTTP-forward agent clears pending timeouts when req.setTimeout disables them", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => proxyUrl,
+      explain: () => {
+        throw new Error("not used");
+      },
+      getProxyForUrl: () => proxyUrl,
+    };
+    const agent = createNodeProxyAgent(resolver, undefined, "http");
+    const req = http.get("http://example.test/allowed", { agent, timeout: 50 }, () => {});
+    let requestError: Error | undefined;
+    req.on("error", (error) => {
+      requestError = error;
+    });
+    try {
+      req.setTimeout(0);
+      for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      assert.equal(activeSockets.size, 1);
+
+      await new Promise((resolve) => setTimeout(resolve, 120));
+
+      assert.equal(requestError, undefined);
+      assert.equal(activeSockets.size, 1);
+    } finally {
+      req.destroy();
+      agent.destroy();
+    }
+  });
+});
+
 test("node HTTP-forward helper agents cancel pending sockets when the request is aborted", async () => {
   await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
     const originalHttpGet = http.get;
@@ -899,6 +1041,93 @@ test("node HTTP-forward helper agents cancel pending sockets when the request is
     }
   });
 });
+
+for (const [protocol, action] of [["http", "timeout"], ["https", "timeout"], ["http", "destroy"]] as const) {
+  test(`node ${protocol} proxy ${action} follows the request selected from the pool`, { timeout: 10_000 }, async () => {
+    const certificate = await createProxyTestCertificate({ dnsNames: ["a.test", "b.test"] });
+    const secureContext = tls.createSecureContext({ key: certificate.privateKey, cert: certificate.certificate });
+    const sockets = new Set<net.Socket>();
+    let connections = 0;
+    let firstTls: tls.TLSSocket | undefined;
+    const proxy = net.createServer((socket) => {
+      connections += 1;
+      sockets.add(socket);
+      socket.on("error", () => {});
+      socket.on("close", () => sockets.delete(socket));
+      if (connections !== 1) {
+        socket.resume();
+        return;
+      }
+      const acceptTls = (): void => {
+        firstTls = new tls.TLSSocket(socket, { isServer: true, secureContext });
+        firstTls.on("error", () => {});
+        firstTls.on("data", () => {});
+      };
+      if (protocol === "https") {
+        socket.once("data", () => {
+          socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          acceptTls();
+        });
+      } else {
+        acceptTls();
+      }
+    });
+    proxy.listen(0, "127.0.0.1");
+    await once(proxy, "listening");
+    const proxyUrl = `${protocol === "http" ? "https" : "http"}://127.0.0.1:${(proxy.address() as AddressInfo).port}`;
+    const agent = withProxyEnv({ HTTP_PROXY: proxyUrl, HTTPS_PROXY: proxyUrl }, () =>
+      createAmbientNodeProxyAgent({ protocol, proxyTls: { ca: certificate.certificate } }),
+    );
+    assert.ok(agent);
+    Object.assign(agent.options, { maxSockets: 1, maxTotalSockets: 1, keepAlive: false });
+    const requests: http.ClientRequest[] = [];
+    const send = (host: string) => {
+      const req = (protocol === "http" ? http : https).get(`${protocol}://${host}/allowed`, {
+        agent, timeout: 0, ca: certificate.certificate,
+      });
+      const result = { req, error: undefined as Error | undefined, timeouts: 0 };
+      req.on("error", (error) => { result.error = error; });
+      req.on("timeout", () => { result.timeouts += 1; });
+      requests.push(req);
+      return result;
+    };
+    try {
+      const first = send("a.test");
+      await once(first.req, "socket");
+      const older = send("b.test");
+      const selected = send("a.test");
+      const selectedError = (): Error | undefined => selected.error;
+      // Releasing A's socket selects A2 ahead of the older B request.
+      assert.ok(firstTls);
+      firstTls.destroy();
+      for (let attempt = 0; attempt < 100 && connections < 2; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.equal(connections, 2);
+      if (action === "destroy") older.req.destroy();
+      else older.req.setTimeout(50);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      assert.equal(older.timeouts, 0);
+      assert.equal(selected.error, undefined);
+      assert.equal(sockets.size, 1);
+
+      if (action === "destroy") selected.req.destroy();
+      else selected.req.setTimeout(50);
+      for (let attempt = 0; attempt < 100 && selectedError() === undefined; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.match(selectedError()?.message ?? "", action === "timeout" ? /timed out/ : /request closed/);
+      assert.equal(selected.timeouts, action === "timeout" ? 1 : 0);
+      assert.equal(older.timeouts, 0);
+    } finally {
+      for (const req of requests) req.destroy();
+      agent.destroy();
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => proxy.close(() => resolve()));
+      await certificate.cleanup();
+    }
+  });
+}
 
 test("node CONNECT agent fails requests when destination TLS closes during handshake", async () => {
   const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -850,6 +850,56 @@ test("node HTTP-forward agent destroys pending proxy sockets when the agent is d
   });
 });
 
+test("node HTTP-forward helper agents cancel pending sockets when the request is aborted", async () => {
+  await withStalledTlsProxy(async (proxyUrl, activeSockets) => {
+    const originalHttpGet = http.get;
+    const handle = installGlobalProxy({ mode: "managed", proxyUrl });
+    const helperAgent = handle.createNodeAgent();
+    const ambientAgent = withProxyEnv({ HTTP_PROXY: proxyUrl, ALL_PROXY: proxyUrl }, () =>
+      createAmbientNodeProxyAgent({ protocol: "http" }),
+    );
+    assert.ok(ambientAgent);
+
+    const assertAbortCancelsPendingSocket = async (agent: http.Agent): Promise<void> => {
+      const req = originalHttpGet("http://example.test/allowed", { agent }, () => {});
+      const requestClosed = new Promise<void>((resolve) => {
+        req.once("error", () => resolve());
+        req.once("close", () => resolve());
+      });
+      try {
+        for (let attempt = 0; attempt < 20 && activeSockets.size === 0; attempt += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        assert.equal(activeSockets.size, 1);
+
+        req.destroy();
+
+        await Promise.race([
+          requestClosed,
+          new Promise<never>((_resolve, reject) => {
+            setTimeout(() => reject(new Error("request remained pending after abort")), 500);
+          }),
+        ]);
+        for (let attempt = 0; attempt < 80 && activeSockets.size > 0; attempt += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        assert.equal(activeSockets.size, 0);
+      } finally {
+        req.destroy();
+      }
+    };
+
+    try {
+      await assertAbortCancelsPendingSocket(helperAgent);
+      await assertAbortCancelsPendingSocket(ambientAgent);
+    } finally {
+      helperAgent.destroy();
+      ambientAgent.destroy();
+      handle.stop();
+    }
+  });
+});
+
 test("node CONNECT agent fails requests when destination TLS closes during handshake", async () => {
   const netMutable = net as unknown as { connect: (...args: unknown[]) => net.Socket };
   const tlsMutable = tls as unknown as { connect: (...args: unknown[]) => tls.TLSSocket };


### PR DESCRIPTION
HTTP-forward requests could remain pending when the proxy never completed its handshake or the caller destroyed the request. The fixes proposed in #25 and #26 address those gaps, but both associate connections through a global request queue. Node's pool can select a same-origin request ahead of an older request from another origin, causing one request's timeout or destruction to fail a different connection.

This combines the timeout and cancellation fixes and replaces the queue with the exact request Node selects in `createSocket`. The same association repairs the existing CONNECT path. It preserves the 30-second default, explicit zero, dynamic request timeouts, and socket cleanup, with cross-origin pool regressions and documentation. Thanks @SebTardif for both original fixes; this branch retains the cancellation commit and credits the timeout work.

Validation:

- Built-package live reproduction on each original PR: timing out B failed A2 on #25; destroying B failed A2 on #26.
- `pnpm check`, `pnpm test`, and `pnpm docs:build` passed in isolated AWS Crabbox on Node 24.18.1: 133 tests plus the package artifact check; coverage 93.62% lines / 82.44% branches / 94.67% functions.
- Built-package live checks through the public ambient helper: HTTP-forward and CONNECT pool isolation, selected-request cancellation, `destroy()`, `abort()`, explicit timeout, explicit zero, and the real 30-second default.
- Live results: explicit 80 ms timeout failed after 88 ms; `destroy()` and `abort()` released sockets after 27/26 ms; the real default expired after 30,014 ms; zero stayed unbounded. Both pooled HTTP and CONNECT requests remained independent.
- [CI](https://github.com/openclaw/proxyline/actions/runs/33367936198): Node 22.19.0, 24, and 26 passed on Linux, macOS, and Windows at `6188c8dba9344ad9c46a5d8d5a9afd6b6dfda046`. [Package workflow](https://github.com/openclaw/proxyline/actions/runs/33367936188) and both CodeQL analyses passed.
- Codex autoreview: clean at its default P0 reporting scope.

This is a replacement candidate for #25 and #26. Neither original PR has been merged or closed.
