### PR TITLE
chore(deps): refresh Node types and build toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.21.0
+          version: 11.24.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.21.0"
+  PNPM_VERSION: "11.24.0"
 
 jobs:
   hydrate:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.21.0
+          version: 11.24.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.21.0
+          version: 11.24.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/proxyline-npm-release.yml
+++ b/.github/workflows/proxyline-npm-release.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.21.0
+          version: 11.24.0
           run_install: false
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24.19.0
+          node-version: 24.20.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
           registry-url: https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/openclaw/proxyline/issues"
   },
   "homepage": "https://proxyline.dev",
-  "packageManager": "pnpm@11.21.0",
+  "packageManager": "pnpm@11.24.0",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -62,7 +62,7 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "devDependencies": {
-    "@types/node": "26.2.0",
+    "@types/node": "26.4.0",
     "@types/ws": "8.18.1",
     "tsx": "4.23.12",
     "typescript": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@types/node':
-        specifier: 26.2.0
-        version: 26.2.0
+        specifier: 26.4.0
+        version: 26.4.0
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
@@ -185,8 +185,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@types/node@26.2.0':
-    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -430,13 +430,13 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@types/node@26.2.0':
+  '@types/node@26.4.0':
     dependencies:
       undici-types: 8.3.0
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.4.0
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true


### PR DESCRIPTION
Refresh the development toolchain while keeping the existing Node minimum, runtime peer contract, and CI assertions intact.

## Dependency changes

- `@types/node`: 26.2.0 → 26.4.0, including its `@types/ws` lockfile reference; regenerated with `pnpm update --latest --dev`.
- pnpm: 11.21.0 → 11.24.0 in `packageManager` and all five workflow pins. [Upstream release notes](https://github.com/pnpm/pnpm/releases/tag/v11.24.0).
- Release-workflow Node: 24.19.0 → 24.20.0. Node 22.19.0 stays pinned in minimum-version verification; the CI matrix already tracks Node 24 and 26.
- All eight GitHub Actions are already pinned to their latest released versions. TypeScript 7.0.2, Undici 8.10.0, ws 8.21.3, @types/ws 8.18.1, and release npm 12.0.2 remain current.
- No major upgrade taken. pnpm 12.1.0 is published on `next-12`, while npm's `latest` remains 11.24.0; keep the established stable channel. pnpm 11.25.0 is similarly on `next-11`.
- `tsx` 4.23.13 was published on 2026-08-30 at 00:46:16 UTC and is held by the repository's existing 2,880-minute minimum release age until 2026-09-01 at 00:46:16 UTC. Retain 4.23.12 and refresh after that hold expires. `pnpm outdated --format json` reports `{}` under the unchanged policy.

These are internal tooling updates; no runtime behavior change or changelog entry.

## Validation and live proof

On macOS arm64, Node 26.8.1, pnpm 11.24.0:

```text
pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 1s using pnpm v11.24.0

pnpm check
ℹ tests 133
ℹ pass 133
ℹ fail 0
ℹ all files            |  93.62 |    82.44 |   94.67 |
ℹ tests 1
ℹ pass 1
ℹ fail 0

pnpm test
ℹ tests 133
ℹ pass 133
ℹ fail 0
ℹ tests 1
ℹ pass 1
ℹ fail 0

pnpm docs:build
built docs site: dist/docs-site

pnpm package:dry-run
exit 0

actionlint
exit 0 (no diagnostics)
```

The following standalone integration imports the built `dist/index.js`, starts the repository's real loopback proxy and origin servers, sends requests through the installed runtime, exercises the explicit CONNECT helper, and checks shutdown restoration:

```sh
node --import tsx --input-type=module <<'NODE'
import assert from 'node:assert/strict';
import http from 'node:http';
import { installGlobalProxy, openProxyConnectTunnel } from './dist/index.js';
import { startProxyLab } from './test/support/proxy-lab.ts';

const lab = await startProxyLab();
const originalFetch = globalThis.fetch;
const originalRequest = http.request;
const proxy = installGlobalProxy({ mode: 'managed', proxyUrl: lab.proxyUrl });
try {
  const allowed = await fetch(`${lab.targetUrl}/allowed`);
  const body = (await allowed.text()).trim();
  assert.equal(allowed.status, 200);
  assert.equal(body, 'allowed via target');
  console.log(`built fetch /allowed -> ${allowed.status}: ${body}`);

  const denied = await fetch(`${lab.targetUrl}/denied`);
  await denied.text();
  assert.equal(denied.status, 403);
  console.log(`built fetch /denied -> ${denied.status}: blocked by proxy`);

  const nodeResult = await new Promise((resolve, reject) => {
    http.get(`${lab.targetUrl}/allowed`, response => {
      let text = '';
      response.setEncoding('utf8');
      response.on('data', chunk => { text += chunk; });
      response.on('end', () => resolve({ status: response.statusCode, body: text.trim() }));
      response.on('error', reject);
    }).on('error', reject);
  });
  assert.deepEqual(nodeResult, { status: 200, body: 'allowed via target' });
  console.log(`built node:http /allowed -> ${nodeResult.status}: ${nodeResult.body}`);

  const target = new URL(lab.targetUrl);
  const tunnel = await openProxyConnectTunnel({
    proxyUrl: lab.proxyUrl,
    targetHost: target.hostname,
    targetPort: Number(target.port),
    timeoutMs: 5000,
  });
  tunnel.write(`GET /allowed HTTP/1.1\r\nHost: ${target.host}\r\nConnection: close\r\n\r\n`);
  let tunneledResponse = '';
  for await (const chunk of tunnel) tunneledResponse += chunk.toString();
  assert.match(tunneledResponse, /^HTTP\/1\.1 200/);
  assert.ok(tunneledResponse.includes('allowed via target'));
  console.log('built CONNECT /allowed -> 200: allowed via target');
  assert.ok(lab.events.some(event => event.type === 'connect'));
  assert.ok(lab.events.some(event => event.type === 'request'));
  console.log('proxy observed CONNECT and absolute-form HTTP traffic');
} finally {
  proxy.stop();
  await lab.close();
}
assert.equal(globalThis.fetch, originalFetch);
assert.equal(http.request, originalRequest);
console.log('stop restored fetch and node:http globals');
NODE
```

Actual output:

```text
built fetch /allowed -> 200: allowed via target
built fetch /denied -> 403: blocked by proxy
built node:http /allowed -> 200: allowed via target
built CONNECT /allowed -> 200: allowed via target
proxy observed CONNECT and absolute-form HTTP traffic
stop restored fetch and node:http globals
```

The first smoke attempt assumed plain HTTP fetch would use CONNECT; it correctly used absolute-form forwarding. The final probe above explicitly opens a CONNECT tunnel and verifies both paths.

## CI reasoning

The orchestrator's `NORUNS` snapshot was stale. Current default-branch commit `3eb7ac70c09087bde605799ccfebbf10ad2ff68b` is green:

- [ci](https://github.com/openclaw/proxyline/actions/runs/33369876578): build, typecheck, coverage, tests and package-artifact checks on Ubuntu, macOS and Windows across Node 22.19.0, 24 and 26, plus workflow linting.
- [package](https://github.com/openclaw/proxyline/actions/runs/33369876556): workflow lint, minimum-Node checks and package dry run.
- [pages](https://github.com/openclaw/proxyline/actions/runs/33369876573): docs build and deployment, an operational workflow rather than a product-test gate.

Crabbox Hydrate is a manual development-environment job, ClawSweeper Dispatch is event-driven automation, and npm release is publication infrastructure. None is a scheduled product-test gate. This PR changes only their toolchain pins; no operational dispatch, deployment, or publication was requested or run.

The PR is for maintainer review and merge; this worker will not merge it.

Codex autoreview completed successfully: `scoped-clean`, with no accepted or actionable findings at its default P0 priority.

Final PR verification for `1c2df2d9acc40ac1f8068672caede9affbdde9b1`: [ci passed](https://github.com/openclaw/proxyline/actions/runs/33379942005) (all nine Node/OS combinations plus workflow lint), and [package passed](https://github.com/openclaw/proxyline/actions/runs/33379941985). No failed jobs or reruns.
