### PR TITLE
chore(deps): refresh proxy test and CI tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.24.0
+          version: 11.25.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "11.24.0"
+  PNPM_VERSION: "11.25.0"
 
 jobs:
   hydrate:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.24.0
+          version: 11.25.0
           run_install: false
 
       - name: Set up Node

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.24.0
+          version: 11.25.0
           run_install: false
 
       - name: Set up Node
@@ -55,4 +55,4 @@ jobs:
 
       - name: Deploy Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/proxyline-npm-release.yml
+++ b/.github/workflows/proxyline-npm-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
         with:
-          version: 11.24.0
+          version: 11.25.0
           run_install: false
 
       - name: Set up Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.9 - Unreleased
 
+- Updated the Undici test peer, Node types, tsx, pnpm, and GitHub Pages deployment tooling.
+
 ## 0.3.8 - 2026-08-31
 
 - Fixed HTTP-forward Node agents to enforce the default 30-second proxy handshake timeout and cancel pending sockets when callers abort or destroy requests; explicit `0` remains unbounded. (#27) Thanks @SebTardif.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/openclaw/proxyline/issues"
   },
   "homepage": "https://proxyline.dev",
-  "packageManager": "pnpm@11.24.0",
+  "packageManager": "pnpm@11.25.0",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -62,11 +62,11 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "devDependencies": {
-    "@types/node": "26.4.0",
+    "@types/node": "26.4.1",
     "@types/ws": "8.18.1",
-    "tsx": "4.23.12",
+    "tsx": "4.23.13",
     "typescript": "^7.0.2",
-    "undici": "8.10.0",
+    "undici": "8.10.1",
     "ws": "8.21.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     devDependencies:
       '@types/node':
-        specifier: 26.4.0
-        version: 26.4.0
+        specifier: 26.4.1
+        version: 26.4.1
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
       tsx:
-        specifier: 4.23.12
-        version: 4.23.12
+        specifier: 4.23.13
+        version: 4.23.13
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       undici:
-        specifier: 8.10.0
-        version: 8.10.0
+        specifier: 8.10.1
+        version: 8.10.1
       ws:
         specifier: 8.21.3
         version: 8.21.3
@@ -185,8 +185,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@types/node@26.4.0':
-    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
+  '@types/node@26.4.1':
+    resolution: {integrity: sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -321,8 +321,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  tsx@4.23.12:
-    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -334,8 +334,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+  undici@8.10.1:
+    resolution: {integrity: sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==}
     engines: {node: '>=22.19.0'}
 
   ws@8.21.3:
@@ -430,13 +430,13 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@types/node@26.4.0':
+  '@types/node@26.4.1':
     dependencies:
       undici-types: 8.3.0
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.4.0
+      '@types/node': 26.4.1
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
@@ -530,7 +530,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  tsx@4.23.12:
+  tsx@4.23.13:
     dependencies:
       esbuild: 0.28.2
     optionalDependencies:
@@ -561,6 +561,6 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.10.0: {}
+  undici@8.10.1: {}
 
   ws@8.21.3: {}


### PR DESCRIPTION
Refresh the repository's pinned development and CI dependencies: `@types/node` 26.4.1, `tsx` 4.23.13, the Undici test peer 8.10.1, and pnpm 11.25.0. Keep the package-manager pin aligned across all five workflows and update `actions/deploy-pages` to its verified v5.0.1 commit. The remaining direct dependencies and Action pins are current.

The Node.js minimum stays at 22.19.0 and the Undici peer range stays at `>=8.5.0 <9`. Production source and the published package version are unchanged. The Unreleased changelog records the tooling refresh.

Validation on Node 24.20.0:

- Frozen pnpm install, TypeScript build and typecheck passed.
- All 133 unit, integration, built-package, and script tests passed with coverage: 93.62% lines, 82.44% branches, 94.67% functions. The coverage stage used `--test-concurrency=2` with the existing thresholds and full test list.
- Real local HTTP(S) proxy and CONNECT traffic, managed fetch enforcement, and global restoration are exercised by the integration and compiled package-entrypoint tests.
- Package artifact test, package dry-run, docs build, and actionlint passed.
- All eight Action commit pins were checked against upstream tags.

No release or deployment was run.

Independent full-candidate P0–P2 review, including the lockfile, found no actionable findings. `pnpm outdated` is empty and `pnpm audit` reports zero vulnerabilities.

Exact-head CI evidence for `c4169229b5a55e1a068513cc334bd4fbd8f70557` is now complete:

- [All nine Node/OS coverage checks and workflow lint passed](https://github.com/openclaw/proxyline/actions/runs/33861202985).
- [Ubuntu Node 24 setup, frozen install, and full `pnpm check` trace](https://github.com/openclaw/proxyline/actions/runs/33861202985/job/100985814086). Expand “Set up pnpm”, “Install dependencies”, and “Coverage-gated check” for the pinned pnpm 11.25.0 install and real HTTP(S)/CONNECT/WebSocket/fetch integration results.
- [Node 22.19.0 package verification and package dry-run passed](https://github.com/openclaw/proxyline/actions/runs/33861202997/job/100985813140).
- [CodeQL passed](https://github.com/openclaw/proxyline/actions/runs/33861200303).

A fresh full-candidate P0–P2 review after these checks also found no actionable findings.
