### PR TITLE
fix(http): cancel pending CONNECT sockets on req.destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 0.3.9 - Unreleased
 
+**Highlights:** Destroying a pending HTTPS request now releases its stalled proxy connection immediately.
+
 - Fixed Node CONNECT agents to cancel pending proxy sockets when callers abort or destroy requests, matching HTTP-forward cancellation. Thanks @SebTardif.
-- Updated the Undici test peer, Node types, tsx, pnpm, and GitHub Pages deployment tooling.
+- Updated the Undici test peer, Node types, tsx, pnpm, Node.js release tooling, and GitHub Pages deployment tooling.
 
 ## 0.3.8 - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.9 - Unreleased
 
+- Fixed Node CONNECT agents to cancel pending proxy sockets when callers abort or destroy requests, matching HTTP-forward cancellation. Thanks @SebTardif.
 - Updated the Undici test peer, Node types, tsx, pnpm, and GitHub Pages deployment tooling.
 
 ## 0.3.8 - 2026-08-31

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -24,7 +24,7 @@ This means caller agents are not just ignored — the per-request agent is repla
 
 HTTP-forward proxy connections and CONNECT handshakes default to a 30-second connection timeout. A request's `timeout` option or `req.setTimeout(ms)` can change the pending handshake timeout; use `0` to leave it unbounded. Expiry emits `timeout` on that request and fails the pending connection with `CONNECT_FAILED`. This applies to the explicit Node helper agents as well as patched requests.
 
-For HTTP-forward requests, `req.destroy()` or `req.abort()` also cancels a pending connection to the proxy. This applies to long-lived helper agents: cancellation releases the pending socket without destroying the whole agent or affecting another queued request.
+For HTTP-forward and CONNECT requests, `req.destroy()` or `req.abort()` also cancels a pending connection to the proxy. This applies to long-lived helper agents: cancellation releases the pending socket without destroying the whole agent or affecting another queued request.
 
 ### TLS identity preservation
 

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -676,6 +676,8 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
     let responseBuffer = Buffer.alloc(0);
     let originalRequestSetTimeout: RequestSetTimeout | undefined;
     let hookedRequestSetTimeout: RequestSetTimeout | undefined;
+    let originalRequestDestroy: RequestDestroy | undefined;
+    let hookedRequestDestroy: RequestDestroy | undefined;
     let tlsSocket: tls.TLSSocket | undefined;
 
     const startPendingTimeout = (timeoutMs: number): void => {
@@ -710,6 +712,18 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
       hookedRequestSetTimeout = undefined;
     };
 
+    const restoreRequestDestroyHook = (): void => {
+      if (
+        request !== undefined &&
+        originalRequestDestroy !== undefined &&
+        request.destroy === hookedRequestDestroy
+      ) {
+        request.destroy = originalRequestDestroy;
+      }
+      originalRequestDestroy = undefined;
+      hookedRequestDestroy = undefined;
+    };
+
     const cleanupProxyHandshakeListeners = (): void => {
       proxySocket.off("data", onData);
       proxySocket.off("error", onError);
@@ -726,6 +740,7 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
         this.#pendingConnectSockets.delete(tlsSocket);
       }
       restoreRequestTimeoutHook();
+      restoreRequestDestroyHook();
       cleanupProxyHandshakeListeners();
       request?.off("abort", onRequestClosed);
       request?.off("close", onRequestClosed);
@@ -871,10 +886,23 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
         startPendingTimeout(timeoutMs);
       }
     }
+    request?.once("timeout", onRequestTimedOut);
+    // Node defers ClientRequest.destroy() until the async socket callback.
+    if (request !== undefined) {
+      originalRequestDestroy = request.destroy;
+      hookedRequestDestroy = function hookedDestroy(this: http.ClientRequest, error?: Error) {
+        const result = originalRequestDestroy?.call(this, error) ?? this;
+        onRequestClosed();
+        return result;
+      };
+      request.destroy = hookedRequestDestroy;
+    }
     request?.once("abort", onRequestClosed);
     request?.once("close", onRequestClosed);
     request?.once("error", onRequestClosed);
-    request?.once("timeout", onRequestTimedOut);
+    if (request?.destroyed) {
+      onRequestClosed();
+    }
 
     proxySocket.once(this.#proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
     proxySocket.on("data", onData);

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1042,7 +1042,7 @@ test("node HTTP-forward helper agents cancel pending sockets when the request is
   });
 });
 
-for (const [protocol, action] of [["http", "timeout"], ["https", "timeout"], ["http", "destroy"]] as const) {
+for (const [protocol, action] of [["http", "timeout"], ["https", "timeout"], ["http", "destroy"], ["https", "destroy"]] as const) {
   test(`node ${protocol} proxy ${action} follows the request selected from the pool`, { timeout: 10_000 }, async () => {
     const certificate = await createProxyTestCertificate({ dnsNames: ["a.test", "b.test"] });
     const secureContext = tls.createSecureContext({ key: certificate.privateKey, cert: certificate.certificate });


### PR DESCRIPTION
## What Problem This Solves

HTTPS CONNECT still only listened for abort, close, and error. Node defers `ClientRequest.destroy()` until the async socket callback, so `https.get` plus `req.destroy()` left the pending proxy socket up until the 30-second default timeout or CONNECT completed. The HTTP-forward agent gained a destroy hook and `request.destroyed` check in [#27](https://github.com/openclaw/proxyline/pull/27). CONNECT did not.

Callers that cancel an HTTPS request during the proxy handshake therefore leaked a TCP connection to the proxy. A long-lived helper agent kept that socket until timeout.

## Evidence

Before the patch, `https.get` through a CONNECT agent plus `req.destroy()` did not fail the selected request. The request stayed pending and the proxy TCP socket stayed up. After the patch, the same public API path fails immediately and the proxy socket closes.

Live run after the patch on Windows, Node v24.19.0, public `createNodeProxyAgent` plus `https.get`, against a `127.0.0.1` proxy that accepts TCP and never answers CONNECT:

```console
$ node --import tsx C:\Users\sebta\AppData\Local\Temp\proxyline-connect-destroy-proof.mjs
proxy_sockets_before_destroy=1
connections_before_destroy=1
request_destroyed_before=false
server_socket_closed connections=1 remaining=0
request_destroyed_after=true
request_error=request closed before proxy CONNECT completed
proxy_sockets_after_destroy=0
connections_after_destroy=1
elapsed_ms=71
```

The proxy accepted one TCP connection. `req.destroy()` closed that socket in 71 ms. No second connection was opened.

## Real behavior proof

- **Behavior or issue addressed:** Pending HTTPS CONNECT sockets stayed open after the caller destroyed the ClientRequest, because Node defers destroy until the async socket callback and CONNECT never hooked destroy.
- **Real environment tested:** Windows, Node v24.19.0, local openclaw/proxyline checkout on branch fix/connect-destroy-pending-sockets, public createNodeProxyAgent plus https.get against a 127.0.0.1 proxy that accepts TCP and never completes CONNECT.
- **Exact steps or command run after this patch:** Started a raw net server on 127.0.0.1, created a CONNECT Node agent with createNodeProxyAgent, called https.get("https://example.test/allowed", { agent, timeout: 0 }), waited until the proxy had one socket, then called req.destroy() and printed socket counts plus the request error.
- **Evidence after fix:** terminal output from the live node command above. One proxy socket before destroy, zero after, request error "request closed before proxy CONNECT completed", elapsed 71 ms.
- **Observed result after fix:** req.destroy() now fails the pending CONNECT handshake and closes the proxy TCP socket without waiting for the 30-second default timeout.
- **What was not tested:** A remote corporate proxy, HTTP/2, and undici fetch cancellation. This path is node:https CONNECT only.

## Summary

Same destroy hook and `request.destroyed` check as the HTTP-forward agent in [#27](https://github.com/openclaw/proxyline/pull/27), applied to `ProxylineConnectAgent.createConnection`. Pool coverage now includes `["https", "destroy"]` next to the existing `["http", "destroy"]` case.

Related:

- [#27](https://github.com/openclaw/proxyline/pull/27) isolated pending timeouts and cancellation for HTTP-forward
- Abort, close, and error listeners only were introduced in [#4](https://github.com/openclaw/proxyline/pull/4) ([`98a53119`](https://github.com/openclaw/proxyline/commit/98a53119449ffaa24fdad889e65ae00513dc05fc), 2026-05-14)
