### PR TITLE
fix(runtime): load installed Undici peer under Bun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.3.10 - Unreleased
+## 0.3.11 - Unreleased
+
+## 0.3.10 - 2026-09-06
+
+- Fixed runtime loading under Bun to use the installed Undici peer for fetch classes and dispatcher cleanup instead of Bun's built-in compatibility module.
 
 ## 0.3.9 - 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npm install @openclaw/proxyline undici@^8.5.0
 
 Proxyline requires Node.js 22.19.0 or newer and a host `undici` version in the `>=8.5.0 <9` range. The package is ESM-only and includes TypeScript declarations.
 
+Proxyline resolves the installed Undici peer explicitly, including when loaded under Bun, so its fetch classes and dispatcher cleanup use the same implementation.
+
 ## Quick start
 
 Save this as `proxy.mjs`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/proxyline",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Process-global proxy routing for Node.js.",
   "type": "module",
   "license": "MIT",

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2,21 +2,14 @@ import http from "node:http";
 import https from "node:https";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { X509Certificate } from "node:crypto";
+import { createRequire } from "node:module";
 import net from "node:net";
+import path from "node:path";
 import tls from "node:tls";
-import {
+import type {
   Agent as UndiciAgent,
   Dispatcher,
-  FormData as UndiciFormData,
-  Headers as UndiciHeaders,
-  Pool as UndiciPool,
-  Request as UndiciRequest,
-  Response as UndiciResponse,
-  errors as undiciErrors,
-  fetch as undiciFetch,
-  getGlobalDispatcher,
   ProxyAgent as UndiciProxyAgent,
-  setGlobalDispatcher,
 } from "undici";
 import {
   createAmbientProxyResolver,
@@ -49,6 +42,25 @@ import type {
   ProxylineUndiciOptions,
 } from "./types.js";
 import { PROXYLINE_DISPATCHER_BRAND } from "./dispatcher-brand.js";
+
+const require = createRequire(import.meta.url);
+// Resolve the installed peer so Bun uses the same fetch classes and dispatcher lifecycle.
+const {
+  Agent,
+  Dispatcher: UndiciDispatcher,
+  FormData: UndiciFormData,
+  Headers: UndiciHeaders,
+  Pool: UndiciPool,
+  Request: UndiciRequest,
+  Response: UndiciResponse,
+  errors: undiciErrors,
+  fetch: undiciFetch,
+  getGlobalDispatcher,
+  ProxyAgent,
+  setGlobalDispatcher,
+}: typeof import("undici") = require(
+  path.join(path.dirname(require.resolve("undici/package.json")), "index.js"),
+);
 
 type RuntimeInstall = {
   ambientEnv: ProxyEnvSnapshot | undefined;
@@ -414,7 +426,7 @@ type UndiciDispatcherOptions = Readonly<{
   proxyCa: string | undefined;
   undici: ProxylineUndiciOptions | undefined;
 }>;
-type UndiciProxyAgentOptions = Exclude<ConstructorParameters<typeof UndiciProxyAgent>[0], string | URL>;
+type UndiciProxyAgentOptions = Exclude<ConstructorParameters<typeof ProxyAgent>[0], string | URL>;
 type UndiciProxyClientFactory = NonNullable<
   UndiciProxyAgentOptions["clientFactory"]
 >;
@@ -461,7 +473,7 @@ function resolveUndiciBaseOptions(
 }
 
 function createUndiciAgent(options: ProxylineUndiciOptions | undefined): UndiciAgent {
-  return new UndiciAgent(resolveUndiciBaseOptions(options));
+  return new Agent(resolveUndiciBaseOptions(options));
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -529,13 +541,13 @@ function createUndiciProxyAgent(
         }
       : undefined;
   const dispatcherFactory = createProxyClientFactory();
-  return new UndiciProxyAgent({
+  return new ProxyAgent({
     ...resolveUndiciBaseOptions(options.undici),
     uri: proxyUrl,
     clientFactory: dispatcherFactory,
     factory: dispatcherFactory,
     ...(proxyTls !== undefined ? { proxyTls } : {}),
-  } as ConstructorParameters<typeof UndiciProxyAgent>[0]);
+  } as ConstructorParameters<typeof ProxyAgent>[0]);
 }
 
 function normalizeUndiciDispatchOptions(
@@ -582,7 +594,7 @@ function reportClosedDispatchError(
   throw error;
 }
 
-class ManagedUndiciDispatcher extends Dispatcher {
+class ManagedUndiciDispatcher extends UndiciDispatcher {
   public readonly [PROXYLINE_DISPATCHER_BRAND] = true;
   readonly #directDispatcher: UndiciAgent;
   readonly #dispatcherOptions: UndiciDispatcherOptions;
@@ -669,7 +681,7 @@ class ManagedUndiciDispatcher extends Dispatcher {
   }
 }
 
-class AmbientUndiciDispatcher extends Dispatcher {
+class AmbientUndiciDispatcher extends UndiciDispatcher {
   public readonly [PROXYLINE_DISPATCHER_BRAND] = true;
   readonly #directDispatcher: UndiciAgent;
   readonly #dispatcherOptions: UndiciDispatcherOptions;


### PR DESCRIPTION
## Problem

Bun substitutes its compatibility module for a bare `undici` import. Proxyline consequently captures a different fetch class family and a dispatcher without the lifecycle methods it calls. Two existing package-entrypoint tests fail under Bun during fetch-global installation and shutdown.

## Change

Resolve the installed Undici peer relative to Proxyline, then load its package entry point. The peer remains shared with the host, and proxy routing, request normalization, assertions, and public APIs are unchanged. Prepare the approved 0.3.10 patch release and preserve the next-version Unreleased changelog section.

## Validation

- Before: two data-only entrypoint cases pass on Node and fail on Bun.
- After: five existing selected entrypoint cases pass on Node 26.8.1 and Bun 1.4.2, covering fetch-global restoration, multipart encoding, ordinary loopback proxy redirect semantics, replaced request bodies, and streaming request bodies.
- Build/typecheck, package-artifact validation, and docs build pass.
- Other policy/TLS/adversarial cases were not run locally; the existing Node CI matrix remains required before release. This fixes the installed-peer loading boundary and does not claim complete Bun compatibility.

## Exact-commit runtime evidence

Verified commit `cd68dac9c7f5dd2c367417d74f55e7305cf5f413`, package `0.3.10`, installed Undici peer `8.10.1`, Node `26.8.1`, Bun `1.4.2`. Rebuilt `dist` at this commit before these runs. Both commands exited 0; the processes completed without cleanup errors. The first case asserts replacement and restoration of all five fetch globals; the final three use the real owned loopback proxy lab and assert response status/body and proxy activity.

```sh
pnpm build
pattern='^package entrypoint (patches and restores fetch globals together|global fetch encodes FormData as multipart|preserves standard options on preinstall Requests|lets fetch init body replace a consumed preinstall Request body|streams preinstall Request bodies without buffering first)$'
node --import tsx --test --test-name-pattern="$pattern" test/package.test.ts
bun test --test-name-pattern="$pattern" test/package.test.ts
```

Actual Bun output:

```text
bun test v1.4.2 (744846f84)

test/package.test.ts:
(pass) package entrypoint patches and restores fetch globals together [4.48ms]
(pass) package entrypoint global fetch encodes FormData as multipart [0.76ms]
(pass) package entrypoint preserves standard options on preinstall Requests [22.89ms]
(pass) package entrypoint lets fetch init body replace a consumed preinstall Request body [6.98ms]
(pass) package entrypoint streams preinstall Request bodies without buffering first [10.22ms]

 5 pass
 3 filtered out
 0 fail
Ran 5 tests across 1 file. [208.00ms]
```

Node output likewise reports the same five names passed, `tests 5`, `pass 5`, `fail 0`, `cancelled 0`, `skipped 0`, with duration `366.526333ms`.

The [full nine-job Node coverage matrix](https://github.com/openclaw/proxyline/actions/runs/34053641974) and [package verification](https://github.com/openclaw/proxyline/actions/runs/34053641929) passed on this head. Local filtered proof is deliberately distinguished from the complete Node CI suite.

Minimum-peer artifact check: packed this commit as `@openclaw/proxyline@0.3.10`, installed the tarball into an isolated consumer with exactly `undici@8.5.0`, and ran the same in-memory install/fetch/restore probe with an empty inherited environment. The probe asserts all four fetch constructors equal the installed peer, successfully reads two data URLs (including a pre-install Request), then asserts every captured global and the original peer dispatcher are restored. No socket is opened. Both processes exited 0:

```json
{"runtime":"Node 26.8.1","proxyline":"0.3.10","sharedPeer":true,"fetchAndRestore":true}
{"runtime":"Bun 1.4.2","proxyline":"0.3.10","sharedPeer":true,"fetchAndRestore":true}
```
