### PR TITLE
fix(runtime): preserve bundled loading and cancellation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.3.11 - Unreleased
+## 0.3.12 - Unreleased
+
+## 0.3.11 - 2026-09-06
+
+- Fixed standalone bundles by importing the installed Undici peer entrypoint statically, preserving Bun compatibility without requiring package metadata beside relocated output.
 
 ## 0.3.10 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 0.3.11 - 2026-09-06
 
 - Fixed standalone bundles by importing the installed Undici peer entrypoint statically, preserving Bun compatibility without requiring package metadata beside relocated output.
+- Preserved caller-supplied cancellation errors when destroying requests during pending HTTP-forward or CONNECT setup.
 
 ## 0.3.10 - 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install @openclaw/proxyline undici@^8.5.0
 
 Proxyline requires Node.js 22.19.0 or newer and a host `undici` version in the `>=8.5.0 <9` range. The package is ESM-only and includes TypeScript declarations.
 
-Proxyline resolves the installed Undici peer explicitly, including when loaded under Bun, so its fetch classes and dispatcher cleanup use the same implementation.
+Proxyline imports the installed Undici peer entrypoint explicitly, including when loaded under Bun, so its fetch classes and dispatcher cleanup use the same implementation. The static import also lets Node-targeted bundlers include that peer in standalone output.
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/proxyline",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Process-global proxy routing for Node.js.",
   "type": "module",
   "license": "MIT",
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@types/node": "26.4.1",
     "@types/ws": "8.18.1",
+    "esbuild": "0.28.2",
     "tsx": "4.23.13",
     "typescript": "^7.0.2",
     "undici": "8.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
+      esbuild:
+        specifier: 0.28.2
+        version: 0.28.2
       tsx:
         specifier: 4.23.13
         version: 4.23.13

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -573,9 +573,9 @@ class ProxylineHttpForwardAgent extends ProxylineRequestAgent {
           fail(new ProxylineError("CONNECT_FAILED", "proxy connection timed out"));
         }
       };
-      const onRequestClosed = (): void => {
+      const onRequestClosed = (error?: Error): void => {
         if (!settled) {
-          fail(new ProxylineError("CONNECT_FAILED", "request closed before proxy connection completed"));
+          fail(error ?? new ProxylineError("CONNECT_FAILED", "request closed before proxy connection completed"));
         }
       };
 
@@ -620,7 +620,7 @@ class ProxylineHttpForwardAgent extends ProxylineRequestAgent {
         originalRequestDestroy = request.destroy;
         hookedRequestDestroy = function hookedDestroy(this: http.ClientRequest, error?: Error) {
           const result = originalRequestDestroy?.call(this, error) ?? this;
-          onRequestClosed();
+          onRequestClosed(error);
           return result;
         };
         request.destroy = hookedRequestDestroy;
@@ -843,9 +843,9 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
       fail(new ProxylineError("CONNECT_FAILED", "proxy socket closed before CONNECT completed"));
     };
 
-    const onRequestClosed = (): void => {
+    const onRequestClosed = (error?: Error): void => {
       if (!settled) {
-        fail(new ProxylineError("CONNECT_FAILED", "request closed before proxy CONNECT completed"));
+        fail(error ?? new ProxylineError("CONNECT_FAILED", "request closed before proxy CONNECT completed"));
       }
     };
 
@@ -892,7 +892,7 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
       originalRequestDestroy = request.destroy;
       hookedRequestDestroy = function hookedDestroy(this: http.ClientRequest, error?: Error) {
         const result = originalRequestDestroy?.call(this, error) ?? this;
-        onRequestClosed();
+        onRequestClosed(error);
         return result;
       };
       request.destroy = hookedRequestDestroy;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2,15 +2,23 @@ import http from "node:http";
 import https from "node:https";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { X509Certificate } from "node:crypto";
-import { createRequire } from "node:module";
 import net from "node:net";
-import path from "node:path";
 import tls from "node:tls";
-import type {
+// The explicit peer entry avoids Bun's builtin while remaining statically bundleable.
+import {
   Agent as UndiciAgent,
   Dispatcher,
+  FormData as UndiciFormData,
+  Headers as UndiciHeaders,
+  Pool as UndiciPool,
+  Request as UndiciRequest,
+  Response as UndiciResponse,
+  errors as undiciErrors,
+  fetch as undiciFetch,
+  getGlobalDispatcher,
   ProxyAgent as UndiciProxyAgent,
-} from "undici";
+  setGlobalDispatcher,
+} from "undici/index.js";
 import {
   createAmbientProxyResolver,
   EMPTY_PROXY_ENV,
@@ -42,25 +50,6 @@ import type {
   ProxylineUndiciOptions,
 } from "./types.js";
 import { PROXYLINE_DISPATCHER_BRAND } from "./dispatcher-brand.js";
-
-const require = createRequire(import.meta.url);
-// Resolve the installed peer so Bun uses the same fetch classes and dispatcher lifecycle.
-const {
-  Agent,
-  Dispatcher: UndiciDispatcher,
-  FormData: UndiciFormData,
-  Headers: UndiciHeaders,
-  Pool: UndiciPool,
-  Request: UndiciRequest,
-  Response: UndiciResponse,
-  errors: undiciErrors,
-  fetch: undiciFetch,
-  getGlobalDispatcher,
-  ProxyAgent,
-  setGlobalDispatcher,
-}: typeof import("undici") = require(
-  path.join(path.dirname(require.resolve("undici/package.json")), "index.js"),
-);
 
 type RuntimeInstall = {
   ambientEnv: ProxyEnvSnapshot | undefined;
@@ -426,7 +415,7 @@ type UndiciDispatcherOptions = Readonly<{
   proxyCa: string | undefined;
   undici: ProxylineUndiciOptions | undefined;
 }>;
-type UndiciProxyAgentOptions = Exclude<ConstructorParameters<typeof ProxyAgent>[0], string | URL>;
+type UndiciProxyAgentOptions = Exclude<ConstructorParameters<typeof UndiciProxyAgent>[0], string | URL>;
 type UndiciProxyClientFactory = NonNullable<
   UndiciProxyAgentOptions["clientFactory"]
 >;
@@ -473,7 +462,7 @@ function resolveUndiciBaseOptions(
 }
 
 function createUndiciAgent(options: ProxylineUndiciOptions | undefined): UndiciAgent {
-  return new Agent(resolveUndiciBaseOptions(options));
+  return new UndiciAgent(resolveUndiciBaseOptions(options));
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -541,13 +530,13 @@ function createUndiciProxyAgent(
         }
       : undefined;
   const dispatcherFactory = createProxyClientFactory();
-  return new ProxyAgent({
+  return new UndiciProxyAgent({
     ...resolveUndiciBaseOptions(options.undici),
     uri: proxyUrl,
     clientFactory: dispatcherFactory,
     factory: dispatcherFactory,
     ...(proxyTls !== undefined ? { proxyTls } : {}),
-  } as ConstructorParameters<typeof ProxyAgent>[0]);
+  } as ConstructorParameters<typeof UndiciProxyAgent>[0]);
 }
 
 function normalizeUndiciDispatchOptions(
@@ -594,7 +583,7 @@ function reportClosedDispatchError(
   throw error;
 }
 
-class ManagedUndiciDispatcher extends UndiciDispatcher {
+class ManagedUndiciDispatcher extends Dispatcher {
   public readonly [PROXYLINE_DISPATCHER_BRAND] = true;
   readonly #directDispatcher: UndiciAgent;
   readonly #dispatcherOptions: UndiciDispatcherOptions;
@@ -681,7 +670,7 @@ class ManagedUndiciDispatcher extends UndiciDispatcher {
   }
 }
 
-class AmbientUndiciDispatcher extends UndiciDispatcher {
+class AmbientUndiciDispatcher extends Dispatcher {
   public readonly [PROXYLINE_DISPATCHER_BRAND] = true;
   readonly #directDispatcher: UndiciAgent;
   readonly #dispatcherOptions: UndiciDispatcherOptions;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -252,6 +252,49 @@ class FakeProxySocket extends Duplex {
   }
 }
 
+for (const transport of ["forward", "connect"] as const) {
+  test(`pending ${transport} requests preserve caller destruction errors`, { timeout: 10_000 }, async () => {
+    const lab = await startProxyLab(
+      transport === "forward" ? { secureProxy: true } : { secureTarget: true },
+    );
+    const resolver: ProxyResolver = {
+      active: true,
+      describeProxy: () => lab.proxyUrl,
+      getProxyForUrl: () => lab.proxyUrl,
+      explain: () => { throw new Error("not used"); },
+    };
+    const agent = createNodeProxyAgent(resolver, lab.proxyCa, transport === "forward" ? "http" : "https");
+    let request: http.ClientRequest | undefined;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const reason = Object.assign(new Error("synthetic caller cancellation"), { code: "SYNTHETIC_CANCEL" });
+      const errors: Error[] = [];
+      request = (transport === "forward" ? http : https).request(lab.targetUrl, {
+        agent,
+        ...(lab.targetCa ? { ca: lab.targetCa } : {}),
+      });
+      const activeRequest = request;
+      const closed = new Promise<void>((resolve) => activeRequest.once("close", resolve));
+      request.on("error", (error) => errors.push(error));
+      request.destroy(reason);
+      await Promise.race([
+        closed,
+        new Promise<never>((_, reject) => {
+          watchdog = setTimeout(() => reject(new Error("owned request did not close")), 5_000);
+        }),
+      ]);
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0], reason);
+      assert.equal(lab.events.length, 0);
+    } finally {
+      clearTimeout(watchdog);
+      request?.destroy();
+      agent.destroy();
+      await lab.close();
+    }
+  });
+}
+
 test("ambient mode routes node:http through HTTP_PROXY", async () => {
   const lab = await startProxyLab();
   const proxy = withProxyEnv({ HTTP_PROXY: lab.proxyUrl }, () =>

--- a/test/package-artifact.test.ts
+++ b/test/package-artifact.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
+import { build } from "esbuild";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -68,5 +69,66 @@ test("packed package includes sources and product docs referenced by metadata", 
         `${file} source is missing: ${source}`,
       );
     }
+  }
+});
+
+test("built runtime restores fetch globals in a relocated standalone bundle", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "proxyline-bundle-"));
+  try {
+    const output = path.join(root, "output", "runtime.mjs");
+    await build({
+      stdin: {
+        contents: `
+import assert from "node:assert/strict";
+import { installGlobalProxy } from ${JSON.stringify(path.join(repoRoot, "dist/index.js"))};
+const keys = ["fetch", "Headers", "Request", "Response", "FormData"];
+const original = Object.fromEntries(keys.map(key => [key, globalThis[key]]));
+const proxy = installGlobalProxy({ mode: "managed", proxyUrl: "http://127.0.0.1:9" });
+try {
+  assert.notEqual(globalThis.Response, original.Response);
+  assert.equal(await (await fetch("data:text/plain,bundled")).text(), "bundled");
+} finally {
+  proxy.stop();
+}
+for (const key of keys) assert.equal(globalThis[key], original[key]);
+await new Promise(resolve => setImmediate(resolve));
+console.log(JSON.stringify({ response: "bundled", restored: true }));
+`,
+        resolveDir: repoRoot,
+        sourcefile: "bundle-fixture.mjs",
+      },
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      target: "node22",
+      outfile: output,
+      banner: {
+        js: 'import { createRequire as bundleRequire } from "node:module"; const require = bundleRequire(import.meta.url);',
+      },
+    });
+    const relocatedRoot = path.join(root, "relocated");
+    fs.mkdirSync(relocatedRoot);
+    const relocated = path.join(relocatedRoot, "runtime.mjs");
+    fs.renameSync(output, relocated);
+    fs.rmSync(path.dirname(output), { recursive: true });
+    const result = spawnSync(process.execPath, [relocated], {
+      cwd: relocatedRoot,
+      encoding: "utf8",
+      timeout: 30_000,
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        HOME: root,
+        USERPROFILE: root,
+        TMPDIR: root,
+        TEMP: root,
+        TMP: root,
+      },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(result.stderr, "");
+    assert.deepEqual(JSON.parse(result.stdout), { response: "bundled", restored: true });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Problem

Two compatibility gaps were found while upgrading OpenClaw from Proxyline 0.3.7:

- The installed-peer lookup added in 0.3.10 remains a runtime `require.resolve('undici/package.json')` after bundling. Relocated standalone output fails with `MODULE_NOT_FOUND`; OpenClaw's existing worker regression caught it in [#140411](https://github.com/openclaw/openclaw/pull/140411).
- The pending HTTP-forward and CONNECT cancellation hooks added in the intervening releases replace an explicit `request.destroy(error)` reason with a new `CONNECT_FAILED` error, losing caller identity and classification.

## Change

Use a static `undici/index.js` import. It selects the installed peer under Bun and lets Node-targeted bundlers include it, removing the dynamic metadata lookup. Forward a supplied destruction error through the existing single-settlement path; no-error closure keeps its existing fallback, and timeout handling stays separate.

Add owner-boundary regressions for relocated bundled execution and both cancellation paths. The bundle test checks in-memory fetch, restoration of all captured globals, empty stderr, natural child exit, and owned temporary cleanup. Cancellation tests assert exact error identity, one error, closed requests, zero proxy application traffic, and awaited fixture cleanup. Declare already-locked esbuild 0.28.2 as a direct test dependency. Prepare patch release 0.3.11 and retain 0.3.12 Unreleased.

## Evidence

Exact final head: `27fbaa914f2e795223321785428479778cd50727`.

Fresh Node regressions failed before their repairs: relocated output could not find `undici/package.json`, and both pending cancellations replaced `SYNTHETIC_CANCEL` with `CONNECT_FAILED`. All three new regressions pass on Node 26.8.1 and Bun 1.4.2. The bundle child uses the same runtime as its outer test.

```sh
pattern='^(built runtime restores fetch globals in a relocated standalone bundle|pending (forward|connect) requests preserve caller destruction errors)$'
node --import tsx --test --test-name-pattern="$pattern" test/e2e.test.ts test/package-artifact.test.ts
bun test --test-name-pattern="$pattern" test/e2e.test.ts test/package-artifact.test.ts
```

Actual final-head Bun output (exit 0):

```text
bun test v1.4.2 (744846f84)

test/package-artifact.test.ts:
(pass) built runtime restores fetch globals in a relocated standalone bundle [105.45ms]

test/e2e.test.ts:
(pass) pending forward requests preserve caller destruction errors [94.47ms]
(pass) pending connect requests preserve caller destruction errors [22.00ms]

 3 pass
 87 filtered out
 0 fail
Ran 3 tests across 2 files. [269.00ms]
```

The corresponding Node run reports the same three cases passed with exit 0. Additional evidence:

- Five ordinary package-entrypoint cases pass on Node and Bun: globals/restoration, multipart encoding, and real loopback proxy redirect/body/streaming behavior.
- An isolated packed 0.3.11 consumer with minimum peer Undici 8.5.0 passes shared-peer identity, in-memory fetch, and restoration on both runtimes.
- Typecheck/build, both artifact tests, docs build, and fresh complete-candidate P2 review pass.
- Independent source review covered all production changes since v0.3.7 in `env.ts`, `node-http.ts`, and `runtime.ts`. It identified the cancellation issue above; reinspection after correction found no remaining finding. Request ownership follows Node's pool selection, cleanup remains owner-bound, observer failures cannot strand globals, hostname normalization preserves matching, and explicit zero timeouts remain unbounded.

The existing full Node CI matrix and package verification gate release. Other policy/TLS/adversarial cases were not run locally, and this does not claim complete Bun compatibility across every networking surface.
