### PR TITLE
test: disable Bun auto-install in standalone bundle proof

### DIFF
--- a/test/package-artifact.test.ts
+++ b/test/package-artifact.test.ts
@@ -80,7 +80,9 @@ test("built runtime restores fetch globals in a relocated standalone bundle", as
       stdin: {
         contents: `
 import assert from "node:assert/strict";
+import { createRequire } from "node:module";
 import { installGlobalProxy } from ${JSON.stringify(path.join(repoRoot, "dist/index.js"))};
+assert.throws(() => createRequire(import.meta.url).resolve("undici/package.json"), { code: "MODULE_NOT_FOUND" });
 const keys = ["fetch", "Headers", "Request", "Response", "FormData"];
 const original = Object.fromEntries(keys.map(key => [key, globalThis[key]]));
 const proxy = installGlobalProxy({ mode: "managed", proxyUrl: "http://127.0.0.1:9" });
@@ -111,7 +113,8 @@ console.log(JSON.stringify({ response: "bundled", restored: true }));
     const relocated = path.join(relocatedRoot, "runtime.mjs");
     fs.renameSync(output, relocated);
     fs.rmSync(path.dirname(output), { recursive: true });
-    const result = spawnSync(process.execPath, [relocated], {
+    // Missing dependencies must not be installed during the relocation proof.
+    const result = spawnSync(process.execPath, [...(process.versions.bun ? ["--no-install"] : []), relocated], {
       cwd: relocatedRoot,
       encoding: "utf8",
       timeout: 30_000,


### PR DESCRIPTION
Bun can auto-install a missing dependency when `require.resolve()` runs, even with a fresh temporary HOME. That could conceal an undeclared runtime package lookup in the standalone-bundle test.

Disable auto-install only for the Bun child and assert that Undici package metadata cannot be resolved from the relocated artifact. The child still uses the actual outer runtime, and existing fetch/restoration, stderr, exit, and cleanup assertions remain intact. No production source, dependency, or version changes.

Validation: the isolated resolution probe returned a real cached package under Bun by default and `MODULE_NOT_FOUND` with `--no-install`. The updated relocated-bundle test passes on Node 26.8.1 and Bun 1.4.2; typecheck and independent P2 review passed.

```sh
node --import tsx --test --test-name-pattern='^built runtime restores fetch globals in a relocated standalone bundle$' test/package-artifact.test.ts
bun test --test-name-pattern='^built runtime restores fetch globals in a relocated standalone bundle$' test/package-artifact.test.ts
```

Recorded Bun result: `1 pass`, `1 filtered out`, `0 fail`, exit 0. The single filtered case is the separate package-contents check. Node likewise reports `tests 1`, `pass 1`, `fail 0`, exit 0.
