### PR TITLE
feat: support prepared proxy connection controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.3.12 - Unreleased
 
+- Added prepared proxy DNS lookups and proxy-specific TLS controls to Node helper agents and raw CONNECT tunnels, including client certificates and explicit server names.
+- Unified proxy socket creation while preserving URL-owned routing, independent destination TLS, and existing request cancellation.
+
 ## 0.3.11 - 2026-09-06
 
 - Fixed standalone bundles by importing the installed Undici peer entrypoint statically, preserving Bun compatibility without requiring package metadata beside relocated output.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Managed mode supports deliberate direct-routing exceptions. A `bypassPolicy` han
 
 For an HTTPS proxy with a private CA, use `proxyTls.ca` or `proxyTls.caFile`. That trust applies only to the proxy connection; destination TLS validation remains separate. See [Proxy TLS](./docs/proxy-tls.md).
 
+Standalone Node helper agents support prepared DNS lookups and proxy client certificates through `createAmbientNodeProxyAgent({ resolveProxyConnectOptions })`. Raw CONNECT callers pass the same controls through `proxyConnect`. The selected proxy URL retains ownership of the connection host and port. See [the connection controls](./docs/api-reference.md#proxyconnectoptions).
+
 ## Observability and lifecycle
 
 `proxy.explain(url)` reports `proxied` or `direct`, the reason, the surface, and a credential-redacted proxy URL when one applies. The optional `onEvent` callback receives installation, shutdown, and decision events.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Every public export, with the exact shape from `src/index.ts`, `src/connect.ts`, and `src/node-http.ts`.
+Every public export, with the exact shape from `src/index.ts`, `src/connect.ts`, `src/node-http.ts`, and `src/proxy-socket.ts`.
 
 ## Functions
 
@@ -45,6 +45,18 @@ const agent = createAmbientNodeProxyAgent({
   proxyTls: { caFile: "/etc/proxy-ca.pem" },
 });
 ```
+
+Supply `resolveProxyConnectOptions` when the application has already approved a
+proxy's DNS lookup or needs client certificates or an explicit TLS server name.
+The resolver receives the selected proxy URL as a string. Its returned properties
+are copied once per cached proxy URL and transport (HTTP-forward or CONNECT).
+Keep referenced certificate and key buffers unchanged for the agent's lifetime.
+Direct requests do not call the resolver. Treat the URL as sensitive when it
+contains proxy credentials; use `redactProxyUrl` before logging it.
+
+The resolver is synchronous: finish asynchronous policy checks and DNS planning
+before making the request. Request cancellation still belongs to the Node
+`ClientRequest`; destroy the request or agent to close pending connections.
 
 ### `redactProxyUrl(value: string | URL): string`
 
@@ -254,6 +266,7 @@ Returns `true` for Proxyline-owned managed and ambient undici dispatchers. Use t
 type OpenProxyConnectTunnelOptions = Readonly<{
   proxyUrl: string | URL;
   proxyTls?: ProxylineTlsOptions;
+  proxyConnect?: ProxyConnectOptions;
   targetHost: string;
   targetPort: number;
   timeoutMs?: number;
@@ -263,6 +276,7 @@ type OpenProxyConnectTunnelOptions = Readonly<{
 
 - `proxyUrl` — `http://` or `https://`. Userinfo becomes a `Proxy-Authorization: Basic` header.
 - `proxyTls` — CA trust for HTTPS proxies. See [Proxy TLS](./proxy-tls.md).
+- `proxyConnect` — prepared connection controls for this proxy hop; see below.
 - `targetHost` / `targetPort` — what to ask the proxy to connect to.
 - `timeoutMs` — overall budget for the CONNECT handshake. Defaults to `30000` when omitted. Pass `0` for no timeout.
 - `signal` — optional caller cancellation; aborting rejects the handshake and destroys its active proxy socket.
@@ -274,9 +288,32 @@ type AmbientNodeProxyAgentOptions = {
   env?: ProxyEnvSnapshot;
   protocol?: "http" | "https";
   proxyTls?: ProxylineTlsOptions;
+  resolveProxyConnectOptions?: (proxyUrl: string) => ProxyConnectOptions;
 };
 ```
 
 - `env` — optional env snapshot. Defaults to reading process env.
 - `protocol` — probe protocol, defaulting to `"https"`.
 - `proxyTls` — CA trust for HTTPS proxy endpoints. See [Proxy TLS](./proxy-tls.md).
+- `resolveProxyConnectOptions` — resolves prepared connection controls for each cached proxy child agent.
+
+### `ProxyConnectOptions`
+
+```ts
+type ProxyConnectOptions = Readonly<
+  Pick<net.TcpNetConnectOpts, "lookup"> &
+  Pick<tls.ConnectionOptions,
+    "ca" | "cert" | "key" | "passphrase" | "servername" | "rejectUnauthorized">
+>;
+```
+
+- `lookup` resolves only the proxy hostname. It never resolves the destination
+  named in a CONNECT request.
+- TLS fields apply only to an HTTPS proxy. `ca` takes precedence over the
+  existing `proxyTls.ca`/`caFile` default. Other TLS fields keep Node's defaults
+  when omitted; destination TLS remains request-owned.
+- The proxy URL always owns the socket host and port. Extra JavaScript properties
+  such as `host`, `port`, `path`, `socket`, or `ALPNProtocols` are ignored.
+  HTTPS proxy connections negotiate HTTP/1.1.
+- No operation signal is cached in these options. Node request cancellation and
+  `openProxyConnectTunnel`'s existing handshake signal keep their own lifetimes.

--- a/docs/proxy-tls.md
+++ b/docs/proxy-tls.md
@@ -61,6 +61,18 @@ const ca = resolveProxyTlsCa({ caFile: "/etc/proxy-ca.pem" });
 // ca is a PEM string, or undefined if no options were supplied
 ```
 
+## Per-proxy connection controls
+
+For a Node helper agent, `resolveProxyConnectOptions(proxyUrl)` can return a
+prepared DNS `lookup`, proxy client `cert`/`key`/`passphrase`, a TLS `servername`,
+`rejectUnauthorized`, and `ca`. Raw CONNECT callers pass the same fields through
+`proxyConnect`. See [the API contract](./api-reference.md#proxyconnectoptions).
+
+These fields configure the proxy hop. They cannot replace the proxy URL's host
+or port, inject a Unix socket path, or change the HTTP/1.1 proxy protocol. An
+explicit `ca` overrides the existing proxy CA default; it does not change trust
+for the tunneled destination.
+
 ## Destination TLS
 
 Destination TLS is independent of `proxyTls`. When you call `https.request(url, { ca, rejectUnauthorized, ... })`, those options apply to the destination handshake exactly as Node would normally apply them. Proxyline only lifts them off a caller-supplied `agent` so they survive the agent replacement; see [Surfaces — TLS identity preservation](./surfaces.md#tls-identity-preservation).

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,10 +1,12 @@
 import net from "node:net";
 import tls from "node:tls";
-import { ProxylineError, decodeProxyUserinfoComponent, type ProxylineTlsOptions, redactProxyUrl, resolveProxyTlsCa } from "./shared.js";
+import { connectToProxy, type ProxyConnectOptions } from "./proxy-socket.js";
+import { ProxylineError, decodeProxyUserinfoComponent, type ProxylineTlsOptions, redactProxyUrl } from "./shared.js";
 
 export type OpenProxyConnectTunnelOptions = Readonly<{
   proxyUrl: string | URL;
   proxyTls?: ProxylineTlsOptions;
+  proxyConnect?: ProxyConnectOptions;
   targetHost: string;
   targetPort: number;
   /**
@@ -37,17 +39,6 @@ const INVALID_CONNECT_HOST_DELIMITER_PATTERN = /[/:?#@\\]/;
 
 type ProxySocket = net.Socket | tls.TLSSocket;
 
-function resolveProxyHost(proxy: URL): string {
-  return (proxy.hostname || proxy.host).replace(/^\[|\]$/g, "");
-}
-
-function resolveProxyPort(proxy: URL): number {
-  if (proxy.port) {
-    return Number(proxy.port);
-  }
-  return proxy.protocol === "https:" ? 443 : 80;
-}
-
 function resolveProxyAuthorization(proxy: URL): string | undefined {
   if (!proxy.username && !proxy.password) {
     return undefined;
@@ -78,31 +69,6 @@ export function formatConnectAuthority(targetHost: string, targetPort: number): 
     throw new ProxylineError("INVALID_CONNECT_TARGET", "CONNECT target host is not a host name.");
   }
   return `${targetHost}:${targetPort}`;
-}
-
-function connectToProxy(proxy: URL, proxyTls: ProxylineTlsOptions | undefined): ProxySocket {
-  const host = resolveProxyHost(proxy);
-  const connectOptions = {
-    host,
-    port: resolveProxyPort(proxy),
-  };
-  if (proxy.protocol === "https:") {
-    const ca = resolveProxyTlsCa(proxyTls);
-    const servername = net.isIP(host) === 0 ? host : undefined;
-    return tls.connect({
-      ...connectOptions,
-      ALPNProtocols: ["http/1.1"],
-      ...(servername !== undefined ? { servername } : {}),
-      ...(ca !== undefined ? { ca } : {}),
-    });
-  }
-  if (proxy.protocol === "http:") {
-    return net.connect(connectOptions);
-  }
-  throw new ProxylineError(
-    "UNSUPPORTED_PROXY_PROTOCOL",
-    `CONNECT tunnels support http:// and https:// proxy endpoints: ${proxy.protocol}`,
-  );
 }
 
 function assertSupportedConnectProxyProtocol(proxy: URL): void {
@@ -245,7 +211,7 @@ export async function openProxyConnectTunnel(
           fail(new Error(`proxy CONNECT timed out after ${connectTimeoutMs}ms`));
         }, connectTimeoutMs);
       }
-      socket = connectToProxy(proxy, options.proxyTls);
+      socket = connectToProxy(proxy, options.proxyTls, options.proxyConnect);
       socket.once(proxy.protocol === "https:" ? "secureConnect" : "connect", onConnected);
       socket.on("data", onData);
       socket.once("error", onError);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { openProxyConnectTunnel, type OpenProxyConnectTunnelOptions } from "./connect.js";
+export type { ProxyConnectOptions } from "./proxy-socket.js";
 export {
   createAmbientNodeProxyAgent,
   hasAmbientNodeProxyConfigured,

--- a/src/node-http.ts
+++ b/src/node-http.ts
@@ -9,7 +9,8 @@ import {
   type ProxyEnvSnapshot,
 } from "./env.js";
 import { formatConnectAuthority, resolveProxyConnectTimeoutMs } from "./connect.js";
-import { ProxylineError, decodeProxyUserinfoComponent, resolveProxyTlsCa, type ProxylineTlsOptions } from "./shared.js";
+import { connectToProxy, type ProxyConnectOptions } from "./proxy-socket.js";
+import { ProxylineError, decodeProxyUserinfoComponent, type ProxylineTlsOptions } from "./shared.js";
 import type { ProxylineSurface, ProxyResolver } from "./types.js";
 
 export type NodeHttpRequestOptions = http.RequestOptions & https.RequestOptions & {
@@ -19,6 +20,7 @@ export type NodeHttpRequestOptions = http.RequestOptions & https.RequestOptions 
 type NodeHttpMethod = typeof http.request;
 type NodeAgentFactory = (options: NodeHttpRequestOptions) => http.Agent;
 type NodeAgentOptions = http.AgentOptions & https.AgentOptions;
+type ResolveProxyConnectOptions = (proxyUrl: string) => ProxyConnectOptions;
 const pendingRequestSymbol = Symbol("proxyline.pendingRequest");
 type NodeAgentRequestOptions = http.RequestOptions & https.RequestOptions & {
   secureEndpoint?: boolean;
@@ -51,6 +53,7 @@ type NodeProxyAgentOptions = NodeAgentOptions & {
     request?: http.ClientRequest,
   ) => string;
   proxyTls?: ProxylineTlsOptions;
+  resolveProxyConnectOptions?: ResolveProxyConnectOptions;
 };
 
 const MAX_CONNECT_RESPONSE_HEADER_BYTES = 16 * 1024;
@@ -193,17 +196,6 @@ export function bindNodeHttpMethod<TMethod extends NodeHttpMethod>(
   }) as TMethod;
 }
 
-function proxyHost(proxy: URL): string {
-  return (proxy.hostname || proxy.host).replace(/^\[|\]$/g, "");
-}
-
-function proxyPort(proxy: URL): number {
-  if (proxy.port) {
-    return Number(proxy.port);
-  }
-  return proxy.protocol === "https:" ? 443 : 80;
-}
-
 function proxyAuthorization(proxy: URL): string | undefined {
   if (!proxy.username && !proxy.password) {
     return undefined;
@@ -211,27 +203,6 @@ function proxyAuthorization(proxy: URL): string | undefined {
   const username = decodeProxyUserinfoComponent(proxy.username);
   const password = decodeProxyUserinfoComponent(proxy.password);
   return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
-}
-
-function proxyConnectOptions(
-  proxy: URL,
-  proxyTls: ProxylineTlsOptions | undefined,
-): net.TcpNetConnectOpts | tls.ConnectionOptions {
-  const host = proxyHost(proxy);
-  const base = {
-    host,
-    port: proxyPort(proxy),
-  };
-  if (proxy.protocol !== "https:") {
-    return base;
-  }
-  const ca = resolveProxyTlsCa(proxyTls);
-  return {
-    ...base,
-    ALPNProtocols: ["http/1.1"],
-    ...(net.isIP(host) === 0 ? { servername: host } : {}),
-    ...(ca !== undefined ? { ca } : {}),
-  };
 }
 
 function assertSupportedNodeProxyProtocol(proxy: URL): void {
@@ -312,16 +283,6 @@ function setForwardProxyRequestPath(
 ): void {
   req._header = null;
   req.path = proxyForwardRequestPath(req, options);
-}
-
-function connectToProxy(
-  proxy: URL,
-  proxyTls: ProxylineTlsOptions | undefined,
-): net.Socket | tls.TLSSocket {
-  const options = proxyConnectOptions(proxy, proxyTls);
-  return proxy.protocol === "https:"
-    ? tls.connect(options as tls.ConnectionOptions)
-    : net.connect(options as net.NetConnectOpts);
 }
 
 function isWebSocketRequest(req: http.ClientRequest): boolean {
@@ -457,13 +418,15 @@ class ProxylineHttpForwardAgent extends ProxylineRequestAgent {
   readonly #pendingConnectSockets = new Set<net.Socket>();
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
+  readonly #proxyConnect: ProxyConnectOptions;
 
-  public constructor(proxy: URL, options: NodeAgentOptions, proxyTls: ProxylineTlsOptions | undefined) {
+  public constructor(proxy: URL, options: NodeAgentOptions, proxyTls: ProxylineTlsOptions | undefined, proxyConnect: ProxyConnectOptions) {
     super(options);
     this.options = options;
     this.#keepAlive = options.keepAlive === true;
     this.#proxy = proxy;
     this.#proxyTls = proxyTls;
+    this.#proxyConnect = proxyConnect;
   }
 
   public override addRequest(req: http.ClientRequest, options: NodeAgentRequestOptions): void {
@@ -477,7 +440,7 @@ class ProxylineHttpForwardAgent extends ProxylineRequestAgent {
     callback?: (error: Error | null, socket: net.Socket) => void,
   ): net.Socket {
     const request = this.takePendingRequest(options);
-    const socket = connectToProxy(this.#proxy, this.#proxyTls);
+    const socket = connectToProxy(this.#proxy, this.#proxyTls, this.#proxyConnect);
     // When Node supplies an async callback, deliver the socket only through that
     // path. Returning the same socket as well double-invokes Agent setup and can
     // hand an unready TLS proxy socket to plain HTTP forward traffic.
@@ -651,13 +614,15 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
   readonly #pendingConnectSockets = new Set<net.Socket>();
   readonly #proxy: URL;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
+  readonly #proxyConnect: ProxyConnectOptions;
 
-  public constructor(proxy: URL, options: NodeAgentOptions, proxyTls: ProxylineTlsOptions | undefined) {
+  public constructor(proxy: URL, options: NodeAgentOptions, proxyTls: ProxylineTlsOptions | undefined, proxyConnect: ProxyConnectOptions) {
     super(options);
     this.options = options;
     this.#keepAlive = options.keepAlive === true;
     this.#proxy = proxy;
     this.#proxyTls = proxyTls;
+    this.#proxyConnect = proxyConnect;
   }
 
   public override createConnection(
@@ -669,7 +634,7 @@ class ProxylineConnectAgent extends ProxylineRequestAgent {
       throw new ProxylineError("INVALID_CONNECT_CALLBACK", "CONNECT agents require an async socket callback.");
     }
 
-    const proxySocket = connectToProxy(this.#proxy, this.#proxyTls);
+    const proxySocket = connectToProxy(this.#proxy, this.#proxyTls, this.#proxyConnect);
     this.#pendingConnectSockets.add(proxySocket);
     let pendingTimeout: ReturnType<typeof setTimeout> | undefined;
     let settled = false;
@@ -934,9 +899,10 @@ export class ProxylineNodeProxyAgent extends http.Agent {
   readonly #httpAgent: NodeAddRequestAgent;
   readonly #httpsAgent: NodeAddRequestAgent;
   readonly #proxyTls: ProxylineTlsOptions | undefined;
+  readonly #resolveProxyConnectOptions: ResolveProxyConnectOptions | undefined;
 
   public constructor(options: NodeProxyAgentOptions) {
-    const { defaultProtocol = "http", getProxyForUrl, proxyTls, ...agentOptions } = options;
+    const { defaultProtocol = "http", getProxyForUrl, proxyTls, resolveProxyConnectOptions, ...agentOptions } = options;
     super(agentOptions);
     if (nodeAgentDefaultPorts.get(this) === 80) {
       nodeAgentDefaultPorts.delete(this);
@@ -945,6 +911,7 @@ export class ProxylineNodeProxyAgent extends http.Agent {
     this.#defaultProtocol = defaultProtocol;
     this.#getProxyForUrl = getProxyForUrl;
     this.#proxyTls = proxyTls;
+    this.#resolveProxyConnectOptions = resolveProxyConnectOptions;
     this.#httpAgent = new http.Agent(agentOptions) as NodeAddRequestAgent;
     this.#httpsAgent = new https.Agent(agentOptions) as unknown as NodeAddRequestAgent;
   }
@@ -1025,9 +992,12 @@ export class ProxylineNodeProxyAgent extends http.Agent {
     const key = `${tunnel ? "connect" : "forward"}:${proxyUrl.href}`;
     let agent = this.#agents.get(key);
     if (agent === undefined) {
+      // Each cached child owns a snapshot; later mutation of the caller's
+      // options cannot change an already-selected proxy connection policy.
+      const proxyConnect = { ...this.#resolveProxyConnectOptions?.(proxyUrl.href) };
       const newAgent = tunnel
-        ? new ProxylineConnectAgent(proxyUrl, this.options, this.#proxyTls)
-        : new ProxylineHttpForwardAgent(proxyUrl, this.options, this.#proxyTls);
+        ? new ProxylineConnectAgent(proxyUrl, this.options, this.#proxyTls, proxyConnect)
+        : new ProxylineHttpForwardAgent(proxyUrl, this.options, this.#proxyTls, proxyConnect);
       agent = newAgent;
       this.#agents.set(key, agent);
     }
@@ -1067,6 +1037,7 @@ export type AmbientNodeProxyAgentOptions = {
   env?: ProxyEnvSnapshot;
   protocol?: "http" | "https";
   proxyTls?: ProxylineTlsOptions;
+  resolveProxyConnectOptions?: ResolveProxyConnectOptions;
 };
 
 function ambientProbeUrl(protocol: "http" | "https"): string {
@@ -1093,5 +1064,8 @@ export function createAmbientNodeProxyAgent(
     defaultProtocol: protocol,
     getProxyForUrl: (url) => resolveAmbientProxyForUrl(url, env) ?? "",
     ...(options.proxyTls !== undefined ? { proxyTls: options.proxyTls } : {}),
+    ...(options.resolveProxyConnectOptions !== undefined
+      ? { resolveProxyConnectOptions: options.resolveProxyConnectOptions }
+      : {}),
   });
 }

--- a/src/proxy-socket.ts
+++ b/src/proxy-socket.ts
@@ -1,0 +1,44 @@
+import net from "node:net";
+import tls from "node:tls";
+import { resolveProxyTlsCa, type ProxylineTlsOptions } from "./shared.js";
+
+/** Connection controls scoped to the proxy hop, never the destination tunnel. */
+export type ProxyConnectOptions = Readonly<
+  Pick<net.TcpNetConnectOpts, "lookup"> &
+  Pick<tls.ConnectionOptions, "ca" | "cert" | "key" | "passphrase" | "servername" | "rejectUnauthorized">
+>;
+
+/** Callers validate the HTTP(S) proxy URL before opening its socket. */
+export function connectToProxy(
+  proxy: URL,
+  proxyTls: ProxylineTlsOptions | undefined,
+  controls: ProxyConnectOptions = {},
+): net.Socket | tls.TLSSocket {
+  const host = proxy.hostname.replace(/^\[|\]$/g, "");
+  // Copy only supported controls. The selected URL owns host/port, and proxy
+  // handshakes require HTTP/1.1 even if a JavaScript caller supplies extra keys.
+  const address = {
+    host,
+    port: proxy.port ? Number(proxy.port) : proxy.protocol === "https:" ? 443 : 80,
+    ...(controls.lookup !== undefined ? { lookup: controls.lookup } : {}),
+  };
+  if (proxy.protocol === "https:") {
+    const ca = controls.ca ?? resolveProxyTlsCa(proxyTls);
+    const servername = controls.servername ?? (net.isIP(host) === 0 ? host : undefined);
+    return tls.connect({
+      ...address,
+      ALPNProtocols: ["http/1.1"],
+      ...(ca !== undefined ? { ca } : {}),
+      ...(controls.cert !== undefined ? { cert: controls.cert } : {}),
+      ...(controls.key !== undefined ? { key: controls.key } : {}),
+      ...(controls.passphrase !== undefined ? { passphrase: controls.passphrase } : {}),
+      ...(servername !== undefined ? { servername } : {}),
+      // An absent option preserves Node's verification default; explicit
+      // undefined would overwrite that default before TLS normalizes it.
+      ...(controls.rejectUnauthorized !== undefined
+        ? { rejectUnauthorized: controls.rejectUnauthorized }
+        : {}),
+    });
+  }
+  return net.connect(address);
+}

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -132,6 +132,25 @@ async function readHttpsOptions(
   });
 }
 
+function pinnedProxyLookup(expectedHostname: string): net.LookupFunction {
+  return (hostname, options, callback) => {
+    assert.equal(hostname, expectedHostname);
+    callback(null, options.all ? [{ address: "127.0.0.1", family: 4 }] : "127.0.0.1", 4);
+  };
+}
+
+async function readProxyTunnel(socket: net.Socket, target: URL): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.setTimeout(2_000, () => socket.destroy(new Error("tunneled response timed out")));
+    socket.on("data", (chunk: string) => { response += chunk; });
+    socket.once("error", reject);
+    socket.once("end", () => resolve(response));
+    socket.write(`GET /allowed HTTP/1.1\r\nHost: ${target.host}\r\nConnection: close\r\n\r\n`);
+  });
+}
+
 async function withConnectRecorder<T>(
   run: (proxyUrl: string, authorities: string[]) => Promise<T>,
 ): Promise<T> {
@@ -1308,6 +1327,233 @@ test("ambient Node proxy helper trusts HTTPS proxy endpoints with scoped proxy T
     await lab.close();
   }
 });
+
+for (const protocol of ["http", "https"] as const) {
+  test(`proxy connection controls pin proxy DNS and retain cached ${protocol} options`, { timeout: 15_000 }, async () => {
+    const lab = await startProxyLab({ secureTarget: protocol === "https" });
+    const proxyUrl = new URL(lab.proxyUrl);
+    proxyUrl.hostname = "pinned-proxy.invalid";
+    const controls = { lookup: pinnedProxyLookup(proxyUrl.hostname) };
+    const resolvedProxies: string[] = [];
+    const agent = withProxyEnv({ HTTP_PROXY: proxyUrl.href, HTTPS_PROXY: proxyUrl.href }, () =>
+      createAmbientNodeProxyAgent({
+        protocol,
+        resolveProxyConnectOptions: (selectedProxy: string) => {
+          resolvedProxies.push(selectedProxy);
+          return controls;
+        },
+      }),
+    );
+    try {
+      assert.ok(agent);
+      const read = () => protocol === "https"
+        ? readHttps(`${lab.targetUrl}/allowed`, { agent, ca: lab.targetCa })
+        : readHttp(`${lab.targetUrl}/allowed`, agent);
+      assert.deepEqual(await read(), { status: 200, body: "allowed via target\n" });
+      controls.lookup = () => { throw new Error("returned proxy options were mutated"); };
+      assert.deepEqual(await read(), { status: 200, body: "allowed via target\n" });
+      assert.deepEqual(resolvedProxies, [proxyUrl.href]);
+      assert.equal(lab.events.filter((event) => event.type === (protocol === "https" ? "connect" : "request")).length, 2);
+    } finally {
+      agent?.destroy();
+      await lab.close();
+    }
+  });
+}
+
+test("proxy connection controls keep two proxy policies separate in one cached agent", { timeout: 15_000 }, async () => {
+  const forward = await startProxyLab({
+    secureProxy: true,
+    proxyHost: "127.0.0.1",
+    proxyCertificateNames: { dnsNames: ["forward-proxy.invalid"], ipAddresses: [] },
+  });
+  try {
+    const tunnel = await startProxyLab({
+      secureProxy: true,
+      proxyHost: "127.0.0.1",
+      proxyCertificateNames: { dnsNames: ["tunnel-proxy.invalid"], ipAddresses: [] },
+      secureTarget: true,
+    });
+    const forwardUrl = new URL(forward.proxyUrl);
+    forwardUrl.hostname = "forward-proxy.invalid";
+    const tunnelUrl = new URL(tunnel.proxyUrl);
+    tunnelUrl.hostname = "tunnel-proxy.invalid";
+    const forwardControls = { lookup: pinnedProxyLookup(forwardUrl.hostname), ca: forward.proxyCa, rejectUnauthorized: true };
+    const tunnelControls = { lookup: pinnedProxyLookup(tunnelUrl.hostname), ca: tunnel.proxyCa, rejectUnauthorized: true };
+    const resolvedProxies: string[] = [];
+    const agent = withProxyEnv({ HTTP_PROXY: forwardUrl.href, HTTPS_PROXY: tunnelUrl.href }, () =>
+      createAmbientNodeProxyAgent({
+        resolveProxyConnectOptions: (selectedProxy: string) => {
+          resolvedProxies.push(selectedProxy);
+          if (selectedProxy === forwardUrl.href) return forwardControls;
+          assert.equal(selectedProxy, tunnelUrl.href);
+          return tunnelControls;
+        },
+      }),
+    );
+    try {
+      assert.ok(agent);
+      const expected = { status: 200, body: "allowed via target\n" };
+      assert.deepEqual(await readHttp(`${forward.targetUrl}/allowed`, agent), expected);
+      assert.deepEqual(await readHttps(`${tunnel.targetUrl}/allowed`, { agent, ca: tunnel.targetCa }), expected);
+      forwardControls.ca = tunnel.proxyCa;
+      tunnelControls.ca = forward.proxyCa;
+      assert.deepEqual(await readHttps(`${tunnel.targetUrl}/allowed`, { agent, ca: tunnel.targetCa }), expected);
+      assert.deepEqual(await readHttp(`${forward.targetUrl}/allowed`, agent), expected);
+      assert.deepEqual(resolvedProxies, [forwardUrl.href, tunnelUrl.href]);
+      assert.equal(forward.events.filter((event) => event.type === "request").length, 2);
+      assert.equal(tunnel.events.filter((event) => event.type === "connect").length, 2);
+    } finally {
+      agent?.destroy();
+      await tunnel.close();
+    }
+  } finally {
+    await forward.close();
+  }
+});
+
+test("proxy connection controls pin raw tunnel DNS without accepting routing overrides", { timeout: 15_000 }, async () => {
+  const lab = await startProxyLab();
+  const proxyUrl = new URL(lab.proxyUrl);
+  proxyUrl.hostname = "pinned-proxy.invalid";
+  const target = new URL(lab.targetUrl);
+  const controls = {
+    lookup: pinnedProxyLookup(proxyUrl.hostname),
+    host: "wrong-proxy.invalid",
+    hostname: "wrong-proxy.invalid",
+    port: 1,
+    path: "/not-a-proxy-socket",
+  };
+  try {
+    const socket = await openProxyConnectTunnel({
+      proxyUrl,
+      proxyConnect: controls,
+      targetHost: target.hostname,
+      targetPort: Number(target.port),
+      timeoutMs: 2_000,
+    });
+    try {
+      const response = await readProxyTunnel(socket, target);
+      assert.match(response, /^HTTP\/1\.1 200 OK/m);
+      assert.match(response, /allowed via target/);
+      assert.ok(lab.events.some((event) => event.type === "connect" && event.authority === target.host));
+    } finally {
+      socket.destroy();
+    }
+  } finally {
+    await lab.close();
+  }
+});
+
+for (const scenario of [
+  { name: "preserve the disabled Node default when verification is omitted", env: "0", rejectUnauthorized: undefined, allowed: true },
+  { name: "honor explicit verification over the disabled Node default", env: "0", rejectUnauthorized: true, allowed: false },
+  { name: "honor explicitly disabled verification over the Node default", env: undefined, rejectUnauthorized: false, allowed: true },
+  { name: "preserve the secure Node default when verification is omitted", env: undefined, rejectUnauthorized: undefined, allowed: false },
+] as const) {
+  test(`proxy connection controls ${scenario.name}`, { timeout: 15_000 }, async () => {
+    const lab = await startProxyLab({ secureProxy: true });
+    const previous = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    const agent = withProxyEnv({ HTTP_PROXY: lab.proxyUrl }, () =>
+      createAmbientNodeProxyAgent({
+        protocol: "http",
+        resolveProxyConnectOptions: () => scenario.rejectUnauthorized === undefined
+          ? {}
+          : { rejectUnauthorized: scenario.rejectUnauthorized },
+      }),
+    );
+    try {
+      if (scenario.env === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      else process.env.NODE_TLS_REJECT_UNAUTHORIZED = scenario.env;
+      assert.ok(agent);
+      const response = readHttp(`${lab.targetUrl}/allowed`, agent);
+      if (scenario.allowed) {
+        assert.deepEqual(await response, { status: 200, body: "allowed via target\n" });
+      } else {
+        await assert.rejects(response, /self.signed certificate|unable to verify/i);
+      }
+    } finally {
+      if (previous === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      else process.env.NODE_TLS_REJECT_UNAUTHORIZED = previous;
+      agent?.destroy();
+      await lab.close();
+    }
+  });
+}
+
+for (const transport of ["http", "https", "raw"] as const) {
+  test(`proxy connection controls preserve proxy mTLS, SNI, and URL routing for ${transport}`, { timeout: 15_000 }, async () => {
+    const passphrase = "proxyline synthetic client key";
+    const client = await createProxyTestCertificate({ extendedKeyUsage: "clientAuth", passphrase });
+    try {
+      const lab = await startProxyLab({
+        secureProxy: true,
+        proxyHost: "127.0.0.1",
+        proxyClientCa: client.certificate,
+        proxyCertificateNames: { dnsNames: ["proxy-identity.example"], ipAddresses: [] },
+        secureTarget: transport === "https",
+      });
+      const proxyUrl = new URL(lab.proxyUrl);
+      proxyUrl.hostname = "pinned-proxy.invalid";
+      assert.ok(lab.proxyCa);
+      const controls = {
+        lookup: pinnedProxyLookup(proxyUrl.hostname),
+        ca: lab.proxyCa,
+        cert: client.certificate,
+        key: client.privateKey,
+        passphrase,
+        servername: "proxy-identity.example",
+        host: "wrong-proxy.invalid",
+        hostname: "wrong-proxy.invalid",
+        port: 1,
+        path: "/not-a-proxy-socket",
+        ALPNProtocols: ["h2"],
+      };
+      let agent: ReturnType<typeof createAmbientNodeProxyAgent>;
+      try {
+        if (transport === "raw") {
+          const target = new URL(lab.targetUrl);
+          const socket = await openProxyConnectTunnel({
+            proxyUrl,
+            proxyConnect: controls,
+            targetHost: target.hostname,
+            targetPort: Number(target.port),
+            timeoutMs: 2_000,
+          });
+          try {
+            assert.ok(socket instanceof tls.TLSSocket);
+            assert.equal(socket.authorized, true);
+            assert.equal(socket.alpnProtocol, "http/1.1");
+            assert.match(await readProxyTunnel(socket, target), /allowed via target/);
+          } finally {
+            socket.destroy();
+          }
+        } else {
+          agent = withProxyEnv({ HTTP_PROXY: proxyUrl.href, HTTPS_PROXY: proxyUrl.href }, () =>
+            createAmbientNodeProxyAgent({
+              protocol: transport,
+              resolveProxyConnectOptions: (selectedProxy: string) => {
+                assert.equal(selectedProxy, proxyUrl.href);
+                return controls;
+              },
+            }),
+          );
+          assert.ok(agent);
+          const response = transport === "https"
+            ? await readHttps(`${lab.targetUrl}/allowed`, { agent, ca: lab.targetCa })
+            : await readHttp(`${lab.targetUrl}/allowed`, agent);
+          assert.deepEqual(response, { status: 200, body: "allowed via target\n" });
+        }
+        assert.ok(lab.events.some((event) => event.type === "proxy_sni" && event.servername === "proxy-identity.example"));
+      } finally {
+        agent?.destroy();
+        await lab.close();
+      }
+    } finally {
+      await client.cleanup();
+    }
+  });
+}
 
 test("ambient Node proxy helper routes HTTP callers even when probing HTTPS by default", async () => {
   const lab = await startProxyLab();

--- a/test/support/proxy-cert.ts
+++ b/test/support/proxy-cert.ts
@@ -15,6 +15,8 @@ export type ProxyTestCertificate = {
 export type ProxyTestCertificateOptions = {
   dnsNames?: string[];
   ipAddresses?: string[];
+  extendedKeyUsage?: "serverAuth" | "clientAuth";
+  passphrase?: string;
 };
 
 function buildSubjectAltNames(options: ProxyTestCertificateOptions): string {
@@ -39,7 +41,7 @@ prompt = no
 CN = Proxyline Test Proxy
 [v3_req]
 keyUsage = critical, digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth
+extendedKeyUsage = ${options.extendedKeyUsage ?? "serverAuth"}
 subjectAltName = @alt_names
 [alt_names]
 ${buildSubjectAltNames(options)}
@@ -61,7 +63,7 @@ export async function createProxyTestCertificate(
       "-x509",
       "-newkey",
       "rsa:2048",
-      "-nodes",
+      ...(options.passphrase === undefined ? ["-nodes"] : ["-passout", `pass:${options.passphrase}`]),
       "-days",
       "1",
       "-keyout",

--- a/test/support/proxy-lab.ts
+++ b/test/support/proxy-lab.ts
@@ -11,6 +11,11 @@ export type ProxyLabOptions = {
   requiredProxyAuthorization?: string;
   secureProxy?: boolean;
   secureTarget?: boolean;
+  proxyClientCa?: string;
+  proxyCertificateNames?: {
+    dnsNames?: string[];
+    ipAddresses?: string[];
+  };
   targetHost?: "127.0.0.1" | "localhost";
   targetCertificateNames?: {
     dnsNames?: string[];
@@ -364,12 +369,17 @@ export async function startProxyLab(options: ProxyLabOptions = {}): Promise<Prox
     });
   };
 
-  const proxyCertificate = options.secureProxy ? await createProxyTestCertificate() : undefined;
+  const proxyCertificate = options.secureProxy
+    ? await createProxyTestCertificate(options.proxyCertificateNames)
+    : undefined;
   const proxy = options.secureProxy
     ? https.createServer(
         {
           cert: proxyCertificate?.certificate,
           key: proxyCertificate?.privateKey,
+          ...(options.proxyClientCa !== undefined
+            ? { ca: options.proxyClientCa, requestCert: true, rejectUnauthorized: true }
+            : {}),
           SNICallback: (servername, callback) => {
             events.push({ type: "proxy_sni", servername });
             callback(
@@ -377,6 +387,7 @@ export async function startProxyLab(options: ProxyLabOptions = {}): Promise<Prox
               tls.createSecureContext({
                 cert: proxyCertificate?.certificate,
                 key: proxyCertificate?.privateKey,
+                ...(options.proxyClientCa !== undefined ? { ca: options.proxyClientCa } : {}),
               }),
             );
           },


### PR DESCRIPTION
Applications that approve proxy DNS addresses or need a proxy client certificate cannot pass those controls to Proxyline's Node helper agents. This forces callers to use a separate proxy agent even though Proxyline already owns connection cancellation and cleanup.

Add `ProxyConnectOptions` for prepared lookup and proxy-only TLS controls. Node helpers resolve and copy the controls per cached proxy URL/transport; raw CONNECT accepts the same options. Both paths now share one socket dialer. The proxy URL retains host/port ownership, destination TLS remains independent, and operation signals keep their existing request/handshake lifetimes.

Validation:
- Six new connection-control cases failed on the baseline with unresolved pinned proxy names.
- Full `pnpm check` passed: 146 tests plus two package artifact tests, with coverage gates.
- Final 11 connection-control cases and typecheck passed, including separate cached proxy policies, encrypted client keys, explicit server names, ignored routing overrides, and Node verification defaults.
- Docs build and package creation passed.
- A packed candidate passed OpenClaw's 136 WebSocket/address-policy tests, three shared agent tests, and 37 Deepgram tests.
- The compiled OpenClaw CLI transcribed a real audio sample through an HTTPS proxy that required a client certificate, with certificate verification enabled and clean connection closure.

Production delta: +73/-88 (net -15); tests/support: +262/-3. No package version bump or release is included.
