### PR TITLE
fix(deps): update undici to 8.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "esbuild": "0.28.2",
     "tsx": "4.23.13",
     "typescript": "^7.0.2",
-    "undici": "8.10.1",
+    "undici": "8.10.2",
     "ws": "8.21.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       undici:
-        specifier: 8.10.1
-        version: 8.10.1
+        specifier: 8.10.2
+        version: 8.10.2
       ws:
         specifier: 8.21.3
         version: 8.21.3
@@ -337,8 +337,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.10.1:
-    resolution: {integrity: sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==}
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
     engines: {node: '>=22.19.0'}
 
   ws@8.21.3:
@@ -564,6 +564,6 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.10.1: {}
+  undici@8.10.2: {}
 
   ws@8.21.3: {}


### PR DESCRIPTION
## Summary

- Update the exact development/test Undici pin from `8.10.1` to `8.10.2`, following the [upstream security patch release](https://github.com/nodejs/undici/releases/tag/v8.10.2).
- Regenerate only the corresponding lock entries with the repository-pinned pnpm `11.25.0`.
- Preserve the public Undici peer range (`>=8.5.0 <9`), Node floor (`>=22.19.0`), and package version (`0.3.11`).

The dependency manifest and lockfile own this development/test baseline. No Proxyline runtime implementation, test implementation, or public contract changes are needed. This update does not assert that the upstream advisories are exploitable through Proxyline.

Production LOC delta: 0. Test LOC delta: 0. Metadata: 6 additions, 6 deletions across two files. No code paths removed.

## Validation

Exact source: `319abbc118388916f14d0db3b72cbef83bc33e3f`.

AWS Crabbox proof on Node `24.18.1` and pnpm `11.25.0`:

- `pnpm install --frozen-lockfile`: passed; installed Undici `8.10.2`.
- `pnpm check`: build and typecheck passed; 147 behavioral tests and two package-artifact tests passed.
- Coverage: 94.06% lines, 83.36% branches, 95.05% functions.
- `pnpm package:dry-run`: passed.
- Unchanged tracked source and SHA-256 identity of both changed files verified before execution; both file hashes remained unchanged afterward.

Existing tests exercise Node HTTP/HTTPS, Undici/global fetch, proxy routing and bypasses, TLS controls, lifecycle behavior, package consumers, and relocated standalone bundles. No version-only regression test was added.

Fresh structured autoreview (Sol/high, default P0 scope) and TruffleHog passed with no findings. `git diff --check` passed. The AWS lease was released after proof.

Native cross-platform CI and independent review remain pre-merge gates.

## Release Context

Development/test dependency maintenance only. No changelog entry, package version bump, tag, or publication is included. The Proxyline release is a separate subsequent step.
